### PR TITLE
Set publish config access to public

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
   "files": [
     ".build"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "@tsd/typescript": "^5.2.2",
     "@types/jest": "^26.0.24",


### PR DESCRIPTION
Tried publishing and the NPM action failed.  Log [here](https://github.com/Anrok/mammoth/actions/runs/6592426225/job/17913025771).  Turns out that since this is a scoped package, it is private by default.  Added a `publishConfig` section to `package.json` to declare access as public.