### PR TITLE
Fix with query return value

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This fork is based on the 1.x version rather than newer 2.x version.  We made th
 
 ### List of changes ([commits](https://github.com/Anrok/mammoth/compare/upstream-v1...main))
 - Changes nullable expressions to use the `null` data type, rather than `undefined`.
+- Fixes `with` query to return the value provided by constructed query.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@anrok/mammoth",
   "license": "MIT",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "./.build/index.js",
   "types": "./.build/index.d.ts",
   "keywords": [

--- a/src/__tests__/with.test.ts
+++ b/src/__tests__/with.test.ts
@@ -112,4 +112,44 @@ describe(`with`, () => {
       }
     `);
   });
+
+  it('should return affected count from update query', async () => {
+    const query = db.with(
+      `test`, () => db.select(star(db.orderLog)).from(db.orderLog),
+      ({ test }) => db.update(db.orderLog).set({product: 'foo'}).from(test).where(db.orderLog.id.eq(test.id)),
+    );
+
+    const result = await query;
+    expect(result).toEqual(0);
+  });
+
+  it('should return affected count from delete query', async () => {
+    const result = await db.with(
+      `test`, () => db.select(star(db.orderLog)).from(db.orderLog),
+      ({ test }) => db.deleteFrom(db.orderLog).using(test).where(db.orderLog.id.eq(test.id)),
+    );
+
+    expect(result).toEqual(0);
+  });
+
+  it('should return rows from insert query', async () => {
+    const result = await db.with(
+      `test`, () => db.select(star(db.orderLog)).from(db.orderLog),
+      ({ test }) => db
+        .insertInto(db.orderLog, ['amount', 'product', 'quantity', 'region'])
+        .select(test.amount, test.product, test.quantity, test.region)
+        .from(test),
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it('should return rows from select query', async () => {
+    const result = await db.with(
+      `test`, () => db.select(star(db.orderLog)).from(db.orderLog),
+      ({ test }) => db.select(test.id).from(test),
+    );
+
+    expect(result).toEqual([]);
+  });
 });

--- a/src/delete.ts
+++ b/src/delete.ts
@@ -41,6 +41,11 @@ export class DeleteQuery<
     return this.returningKeys;
   }
 
+  /** @internal */
+  newQueryWithTokens(tokens: Array<Token>) {
+    return new DeleteQuery(this.queryExecutor, this.returningKeys, this.table, this.resultType, tokens) as any;
+  }
+
   constructor(
     private readonly queryExecutor: QueryExecutorFn,
     private readonly returningKeys: string[],

--- a/src/insert.ts
+++ b/src/insert.ts
@@ -34,6 +34,11 @@ export class InsertQuery<
     return this.returningKeys;
   }
 
+    /** @internal */
+  newQueryWithTokens(tokens: Array<Token>) {
+    return new InsertQuery(this.queryExecutor, this.returningKeys, this.table, this.resultType, tokens) as any;
+  }
+
   constructor(
     private readonly queryExecutor: QueryExecutorFn,
     private readonly returningKeys: string[],

--- a/src/query.ts
+++ b/src/query.ts
@@ -19,4 +19,6 @@ export abstract class Query<Returning> {
   abstract toTokens(includeAlias?: boolean): Token[];
   /** @internal */
   abstract getReturningKeys(): string[];
+
+  abstract newQueryWithTokens(tokens: Token[]): Query<Returning>;
 }

--- a/src/select.ts
+++ b/src/select.ts
@@ -144,6 +144,11 @@ export class SelectQuery<
     return this.returningKeys;
   }
 
+  /** @internal */
+  newQueryWithTokens(tokens: Token[]): Query<Columns> {
+    return this.newSelectQuery(tokens);
+  }
+
   constructor(
     private readonly queryExecutor: QueryExecutorFn,
     private readonly returningKeys: string[],

--- a/src/update.ts
+++ b/src/update.ts
@@ -28,6 +28,11 @@ export class UpdateQuery<
     return this.returningKeys;
   }
 
+  /** @internal */
+  newQueryWithTokens(tokens: Array<Token>) {
+    return new UpdateQuery(this.queryExecutor, this.returningKeys, this.table, this.resultType, tokens) as any;
+  }
+
   constructor(
     private readonly queryExecutor: QueryExecutorFn,
     private readonly returningKeys: string[],

--- a/src/with.ts
+++ b/src/with.ts
@@ -6,6 +6,8 @@ import { Query } from './query';
 import { CapturingResultSet } from './result-set';
 import { SelectQuery } from './select';
 import { wrapQuotes } from './naming';
+import {UpdateQuery} from './update';
+import {DeleteQuery} from './delete';
 
 export type FromItem<Q> = Q extends Query<any>
   ? FromItemQuery<Q>
@@ -492,9 +494,9 @@ export const makeWith =
 
     const query: Query<any> = callback(queries);
 
-    return new SelectQuery(queryExecutor, [], false, [
+    return query.newQueryWithTokens([
       new StringToken(`WITH`),
       new SeparatorToken(`,`, tokens),
       ...query.toTokens(),
-    ]) as any;
+    ]);
   };


### PR DESCRIPTION
Using `with` on a query should return same `Returning` type as the query created by the callback.  Instead, it was always creating a `SelectQuery` regardless of the type of query that the callback creates.  This would end up returning `[]` when `with` is used on an `UpdateQuery` or `DeleteQuery`, rather than the number of rows affected.  This fixes it to return a copy of the same query instance that is passed in.