### PR TITLE
Remove not used `@tsd/typescript`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
-        "@tsd/typescript": "^5.4.3",
         "@types/jest": "^29.5.12",
         "@types/node": "^16.18.94",
         "jest": "^29.7.0",
@@ -966,15 +965,6 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
-      }
-    },
-    "node_modules/@tsd/typescript": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/@tsd/typescript/-/typescript-5.4.3.tgz",
-      "integrity": "sha512-htCVCSQP58wZcLfQaT7ikW9hSjJN7ntIe0HzAfYpBauI0tYoIM0ow4XEZGFwYN266qEsJoOHhlnkNvz/gLrx4Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@tsd/typescript": "^5.4.3",
     "@types/jest": "^29.5.12",
     "@types/node": "^16.18.94",
     "jest": "^29.7.0",


### PR DESCRIPTION
To draw your attention, you can also remove `@tsd/typescript`. Out is not used after migrating to TSTyche (#11), because it will use TypeScript you have installed in the repo.

---

Happy to see another project using TSTyche! I am its author. Ping me if there would be any questions.