### PR TITLE
Support values list in delete and update queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@anrok/mammoth",
   "license": "MIT",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "./.build/index.js",
   "types": "./.build/index.d.ts",
   "keywords": [

--- a/src/__tests__/delete.test.ts
+++ b/src/__tests__/delete.test.ts
@@ -41,4 +41,25 @@ describe(`delete`, () => {
       }
     `);
   });
+
+  it(`should delete from values list`, () => {
+    const valuesList = db.values(
+      'vals',
+      {
+        name: text().notNull(),
+      },
+      [{ name: 'foo' }],
+    );
+
+    const query = db.deleteFrom(db.foo).using(valuesList).where(db.foo.name.eq(valuesList.name));
+
+    expect(toSql(query)).toMatchInlineSnapshot(`
+      {
+        "parameters": [
+          "foo",
+        ],
+        "text": "DELETE FROM foo USING (VALUES ($1 :: text)) AS vals ("name") WHERE foo.name = vals.name",
+      }
+    `);
+  });
 });

--- a/src/__tests__/update.test.ts
+++ b/src/__tests__/update.test.ts
@@ -51,6 +51,33 @@ describe(`update`, () => {
     `);
   });
 
+  it(`should update from values list`, () => {
+    const valuesList = db.values(
+      'vals',
+      {
+        name: text().notNull(),
+        value: integer(),
+      },
+      [{ name: 'foo', value: 1 }],
+    );
+
+    const query = db
+      .update(db.foo)
+      .set({ value: valuesList.value })
+      .from(valuesList)
+      .where(db.foo.name.eq(valuesList.name));
+
+    expect(toSql(query)).toMatchInlineSnapshot(`
+      {
+        "parameters": [
+          "foo",
+          1,
+        ],
+        "text": "UPDATE foo SET value = vals.value FROM (VALUES ($1 :: text, $2 :: integer)) AS vals ("name", "value") WHERE foo.name = vals.name",
+      }
+    `);
+  });
+
   it(`should update-from foo with reserved keyword alias`, () => {
     const test = db.bar.as('user');
     const query = db

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -9,6 +9,7 @@ import {
 } from './tokens';
 
 import { wrapQuotes } from './naming';
+import { isTokenable } from './sql-functions';
 
 export class Expression<DataType, IsNotNull extends boolean, Name extends string> {
   private _expressionBrand!: ['expression', DataType, IsNotNull, Name];
@@ -32,12 +33,7 @@ export class Expression<DataType, IsNotNull extends boolean, Name extends string
   ) {}
 
   private getDataTypeTokens(value: DataType | Expression<DataType, boolean, any> | Query<any>) {
-    if (
-      value &&
-      typeof value === `object` &&
-      'toTokens' in value &&
-      typeof value.toTokens === `function`
-    ) {
+    if (isTokenable(value)) {
       if (value instanceof Query) {
         return [new GroupToken(value.toTokens())];
       }

--- a/src/insert.ts
+++ b/src/insert.ts
@@ -20,6 +20,7 @@ import { Table } from './TableType';
 import { TableDefinition } from './table';
 import { UpdateQuery } from './update';
 import { wrapQuotes } from './naming';
+import { isTokenable } from './sql-functions';
 
 // https://www.postgresql.org/docs/12/sql-insert.html
 export class InsertQuery<
@@ -364,12 +365,7 @@ export class InsertQuery<
                 >;
                 const value = (values as any)[columnName];
 
-                if (
-                  value &&
-                  typeof value === `object` &&
-                  'toTokens' in value &&
-                  typeof value.toTokens === `function`
-                ) {
+                if (isTokenable(value)) {
                   return new CollectionToken([
                     new StringToken(column.getSnakeCaseName()),
                     new StringToken(`=`),
@@ -467,12 +463,7 @@ export class InsertQuery<
                 >;
                 const value = (values as any)[columnName];
 
-                if (
-                  value &&
-                  typeof value === `object` &&
-                  'toTokens' in value &&
-                  typeof value.toTokens === `function`
-                ) {
+                if (isTokenable(value)) {
                   return new CollectionToken([
                     new StringToken(column.getSnakeCaseName()),
                     new StringToken(`=`),
@@ -692,9 +683,7 @@ export const makeInsertInto =
                   return new CollectionToken([
                     new StringToken(column.getSnakeCaseName()),
                     new StringToken(`=`),
-                    value && typeof value === `object` && 'toTokens' in value
-                      ? value.toTokens()
-                      : new ParameterToken(value),
+                    ...(isTokenable(value) ? value.toTokens() : [new ParameterToken(value)]),
                   ]);
                 }),
               ),
@@ -742,12 +731,7 @@ export const makeInsertInto =
                   Object.keys(values).map((columnName) => {
                     const value = (values as any)[columnName];
 
-                    if (
-                      value &&
-                      typeof value === `object` &&
-                      'toTokens' in value &&
-                      typeof value.toTokens === `function`
-                    ) {
+                    if (isTokenable(value)) {
                       return new GroupToken([new CollectionToken(value.toTokens())]);
                     } else {
                       return new ParameterToken(value);

--- a/src/sql-functions.ts
+++ b/src/sql-functions.ts
@@ -22,7 +22,7 @@ export interface Tokenable {
 }
 
 export const isTokenable = (value: any): value is Tokenable =>
-  value && typeof value === 'object' && 'toTokens' in value;
+  value && typeof value === 'object' && 'toTokens' in value && typeof value.toTokens === `function`;
 
 export class Star {
   private _starBrand: any;

--- a/src/update.ts
+++ b/src/update.ts
@@ -15,6 +15,7 @@ import { ResultSet } from './result-set';
 import { Table } from './TableType';
 import { wrapQuotes } from './naming';
 import { FromItem } from './with';
+import { isTokenable } from './sql-functions';
 
 // https://www.postgresql.org/docs/12/sql-update.html
 export class UpdateQuery<
@@ -359,9 +360,7 @@ export const makeUpdate =
               return new CollectionToken([
                 new StringToken(wrapQuotes(column.getSnakeCaseName())),
                 new StringToken(`=`),
-                ...(value && typeof value === `object` && 'toTokens' in value
-                  ? value.toTokens()
-                  : [new ParameterToken(value)]),
+                ...(isTokenable(value) ? value.toTokens() : [new ParameterToken(value)]),
               ]);
             }),
           ),


### PR DESCRIPTION
In #9, we added values list support in select queries.  This adds the same support to delete and update queries as well.  I also noticed some duplicated code checking if a variable has a `toTokens` function, and replaced these usages with the `isTokenable` helper.