### PR TITLE
Values list: Add test case for extra parameters

### DIFF
--- a/src/__tests__/values.test.ts
+++ b/src/__tests__/values.test.ts
@@ -107,6 +107,27 @@ describe(`valuesList`, () => {
     `);
   });
 
+  it(`should only include parameters from definition`, () => {
+    const params = [
+      { id: 1, product: 'foo', fooId: 'a1' },
+      { id: 2, product: 'bar', fooId: null },
+    ];
+
+    const valuesList = db.values('vals', {id: integer().notNull()}, params);
+
+    const query = db.select(valuesList.id).from(valuesList);
+
+    expect(toSql(query)).toMatchInlineSnapshot(`
+      {
+        "parameters": [
+          1,
+          2,
+        ],
+        "text": "SELECT vals.id FROM (VALUES ($1 :: integer), ($2)) AS vals ("id")",
+      }
+    `);
+  });
+
   it(`should join a values list`, () => {
     const query = db
       .select(db.orderLog.id)

--- a/src/__tests__/values.test.ts
+++ b/src/__tests__/values.test.ts
@@ -113,7 +113,7 @@ describe(`valuesList`, () => {
       { id: 2, product: 'bar', fooId: null },
     ];
 
-    const valuesList = db.values('vals', {id: integer().notNull()}, params);
+    const valuesList = db.values('vals', { id: integer().notNull() }, params);
 
     const query = db.select(valuesList.id).from(valuesList);
 


### PR DESCRIPTION
The `values` function can receive values that have extra properties that the definition does not specify.  It is convenient to support this, because a developer may be working with the results from a query that selects additional columns that are not needed for the query that uses the values list.

This adds a test to ensure that only properties from the definition are tokenized and end up in the resulting SQL.  The test passed without any changes needed, just want to make sure that we continue to support this.