### PR TITLE
Upgrade TSTyche to v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3446,15 +3446,15 @@
       }
     },
     "node_modules/tstyche": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/tstyche/-/tstyche-1.1.0.tgz",
-      "integrity": "sha512-ZvDeScrBJf6053bdOkGUtnfDn7414XjmjGWrDntQfSmtPvxv9HVJ+03GFK2O46hfoAI9L5Q22uw6xy5ZTBdPGg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tstyche/-/tstyche-2.0.0.tgz",
+      "integrity": "sha512-1LUCZEmMLRL7P0qDNtjx8oEEpU4qVUNggpsitl3XSGyuorbSNfees+EmMDC0VZ9FuClD0Far262U9oAT6Vz83Q==",
       "dev": true,
       "bin": {
         "tstyche": "build/bin.js"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16.14"
       },
       "funding": {
         "url": "https://github.com/tstyche/tstyche?sponsor=1"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "jest": "^29.7.0",
     "prettier": "^3.2.5",
     "ts-jest": "^29.1.2",
-    "tstyche": "^1.1.0",
+    "tstyche": "^2.0.0",
     "typescript": "^5.4.3"
   },
   "scripts": {

--- a/src/__checks__/data-types.check.ts
+++ b/src/__checks__/data-types.check.ts
@@ -220,7 +220,7 @@ describe('data-types', () => {
           )
           .from(db.foo),
       ),
-    ).type.toEqual<{
+    ).type.toBe<{
       int8: string | null;
       bigint: string | null;
       bigserial: string | null;

--- a/src/__checks__/delete.check.ts
+++ b/src/__checks__/delete.check.ts
@@ -18,14 +18,14 @@ const db = defineDb({ foo }, () => Promise.resolve({ rows: [], affectedCount: 0 
 
 describe('delete', () => {
   test('should delete and returning id', () => {
-    expect(toSnap(db.deleteFrom(db.foo).returning(`id`))).type.toEqual<{ id: string }>();
+    expect(toSnap(db.deleteFrom(db.foo).returning(`id`))).type.toBe<{ id: string }>();
   });
 
   test('should delete and await affected row count', async () => {
-    expect(await db.deleteFrom(db.foo)).type.toEqual<number>();
+    expect(await db.deleteFrom(db.foo)).type.toBeNumber();
   });
 
   test('should delete and await rows', async () => {
-    expect(await db.deleteFrom(db.foo).returning(`id`)).type.toEqual<{ id: string }[]>();
+    expect(await db.deleteFrom(db.foo).returning(`id`)).type.toBe<{ id: string }[]>();
   });
 });

--- a/src/__checks__/insert.check.ts
+++ b/src/__checks__/insert.check.ts
@@ -35,19 +35,19 @@ const db = defineDb({ foo, serialTest }, () => Promise.resolve({ rows: [], affec
 
 describe('insert', () => {
   test('should insert and returning count', () => {
-    expect(toSnap(db.insertInto(db.foo).values({ name: `Test` }))).type.toEqual<number>();
+    expect(toSnap(db.insertInto(db.foo).values({ name: `Test` }))).type.toBeNumber();
   });
 
   test('should insert multiple rows and returning count', () => {
     expect(
       toSnap(db.insertInto(db.foo).values([{ name: `Test` }, { name: `Test 2` }])),
-    ).type.toEqual<number>();
+    ).type.toBeNumber();
   });
 
   test('should insert default column', () => {
     expect(
       toSnap(db.insertInto(db.foo).values({ name: `Test`, createDate: new Date() })),
-    ).type.toEqual<number>();
+    ).type.toBeNumber();
   });
 
   test('should not insert unknown column', () => {
@@ -65,17 +65,17 @@ describe('insert', () => {
   });
 
   test('should insert and await affect count', async () => {
-    expect(await db.insertInto(db.foo).values({ name: `Test` })).type.toEqual<number>();
+    expect(await db.insertInto(db.foo).values({ name: `Test` })).type.toBeNumber();
   });
 
   test('should insert-returning and await rows', async () => {
-    expect(await db.insertInto(db.foo).values({ name: `Test` }).returning(`name`)).type.toEqual<
+    expect(await db.insertInto(db.foo).values({ name: `Test` }).returning(`name`)).type.toBe<
       { name: string }[]
     >();
   });
 
   test('should insert without explicit value for column serial', () => {
-    expect(db.insertInto(db.serialTest).values({ value: 123 })).type.toEqual<
+    expect(db.insertInto(db.serialTest).values({ value: 123 })).type.toBe<
       InsertQuery<
         Table<
           'serialTest',
@@ -96,7 +96,7 @@ describe('insert', () => {
   test('should insert with expression of the not-null correct type', () => {
     expect(
       db.insertInto(db.serialTest).values({ value: raw<number, true>`get_value()` }),
-    ).type.toEqual<
+    ).type.toBe<
       InsertQuery<
         Table<
           'serialTest',
@@ -117,7 +117,7 @@ describe('insert', () => {
   test('should insert with expression of the nullable correct type', () => {
     expect(
       db.insertInto(db.serialTest).values({ value: raw<number, false>`get_value()` }),
-    ).type.toEqual<
+    ).type.toBe<
       InsertQuery<
         Table<
           'serialTest',
@@ -146,7 +146,7 @@ describe('insert', () => {
       db
         .insertInto(db.foo)
         .values({ name: db.select(db.foo.name.concat(` 2`)).from(db.foo).limit(1) }),
-    ).type.toEqual<
+    ).type.toBe<
       InsertQuery<
         Table<
           'foo',

--- a/src/__checks__/select.check.ts
+++ b/src/__checks__/select.check.ts
@@ -42,7 +42,7 @@ const bar = defineTable({
 });
 
 test('should output all columns and the data type', () => {
-  expect(toTableRow(foo)).type.toEqual<{
+  expect(toTableRow(foo)).type.toBe<{
     id: string;
     createDate: Date;
     name: string;
@@ -56,7 +56,7 @@ describe('select', () => {
   test('should return null and not null properties', () => {
     expect(
       toSnap(db.select(db.foo.id, db.foo.createDate, db.foo.value).from(db.foo)),
-    ).type.toEqual<{
+    ).type.toBe<{
       id: string;
       createDate: Date;
       value: number | null;
@@ -66,7 +66,7 @@ describe('select', () => {
   test('should return nullable properties of left joined columns', () => {
     expect(
       toSnap(db.select(db.foo.id, db.bar.endDate, db.bar.value).from(db.foo).leftJoin(db.bar)),
-    ).type.toEqual<{
+    ).type.toBe<{
       id: string;
       endDate: Date | null;
       value: number | null;
@@ -76,7 +76,7 @@ describe('select', () => {
   test('should return nullable properties of left side properties when right joining', () => {
     expect(
       toSnap(db.select(db.foo.name, db.bar.startDate, db.bar.value).from(db.foo).rightJoin(db.bar)),
-    ).type.toEqual<{
+    ).type.toBe<{
       value: number | null;
       name: string | null;
       startDate: Date;
@@ -84,7 +84,7 @@ describe('select', () => {
   });
 
   test('should select * and return nullable properties of left side properties when right joining', () => {
-    expect(toSnap(db.select(star()).from(db.foo).rightJoin(db.bar))).type.toEqual<{
+    expect(toSnap(db.select(star()).from(db.foo).rightJoin(db.bar))).type.toBe<{
       id: unknown;
       createDate: Date | null;
       name: string | null;
@@ -96,7 +96,7 @@ describe('select', () => {
   });
 
   test('should select foo.* and ignore the rest', () => {
-    expect(toSnap(db.select(star(db.foo)).from(db.foo).innerJoin(db.bar))).type.toEqual<{
+    expect(toSnap(db.select(star(db.foo)).from(db.foo).innerJoin(db.bar))).type.toBe<{
       id: string;
       createDate: Date;
       name: string;
@@ -107,7 +107,7 @@ describe('select', () => {
   test('should return renamed properties because of alias', () => {
     expect(
       toSnap(db.select(db.foo.name.as(`fooName`), db.foo.value.as(`fooValue`)).from(db.foo)),
-    ).type.toEqual<{
+    ).type.toBe<{
       fooName: string;
       fooValue: number | null;
     }>();
@@ -116,7 +116,7 @@ describe('select', () => {
   test('should return nullable properties of all sides because of full join', () => {
     expect(
       toSnap(db.select(db.foo.name, db.bar.startDate, db.bar.value).from(db.foo).fullJoin(db.bar)),
-    ).type.toEqual<{
+    ).type.toBe<{
       value: number | null;
       name: string | null;
       startDate: Date | null;
@@ -124,13 +124,13 @@ describe('select', () => {
   });
 
   test('should select expression', () => {
-    expect(toSnap(db.select(db.foo.value.plus(1)).from(db.foo))).type.toEqual<{
+    expect(toSnap(db.select(db.foo.value.plus(1)).from(db.foo))).type.toBe<{
       '?column?': number | null;
     }>();
   });
 
   test('should select named expression', () => {
-    expect(toSnap(db.select(db.foo.value.plus(1).as(`test`)).from(db.foo))).type.toEqual<{
+    expect(toSnap(db.select(db.foo.value.plus(1).as(`test`)).from(db.foo))).type.toBe<{
       test: number | null;
     }>();
   });
@@ -138,14 +138,14 @@ describe('select', () => {
   test('should select aggregate subquery', () => {
     expect(
       toSnap(db.select(db.foo.id, db.select(count()).from(db.foo)).from(db.foo)),
-    ).type.toEqual<{
+    ).type.toBe<{
       id: string;
       count: string;
     }>();
   });
 
   test('should select array_agg', () => {
-    expect(toSnap(db.select(arrayAgg(db.foo.name)).from(db.foo))).type.toEqual<{
+    expect(toSnap(db.select(arrayAgg(db.foo.name)).from(db.foo))).type.toBe<{
       arrayAgg: string[] | null;
     }>();
   });
@@ -153,27 +153,27 @@ describe('select', () => {
   test('should select null column in subquery', () => {
     expect(
       toSnap(db.select(db.foo.id, db.select(db.foo.value).from(db.foo)).from(db.foo)),
-    ).type.toEqual<{
+    ).type.toBe<{
       id: string;
       value: number | null;
     }>();
   });
 
   test('should select aggregate with alias', () => {
-    expect(toSnap(db.select(db.foo.id, sum(db.foo.value).as(`total`)).from(db.foo))).type.toEqual<{
+    expect(toSnap(db.select(db.foo.id, sum(db.foo.value).as(`total`)).from(db.foo))).type.toBe<{
       id: string;
       total: number | null;
     }>();
   });
 
   test('should convert null value to not null using coalesce', () => {
-    expect(toSnap(db.select(coalesce(db.foo.value, 1)).from(db.foo))).type.toEqual<{
+    expect(toSnap(db.select(coalesce(db.foo.value, 1)).from(db.foo))).type.toBe<{
       coalesce: number;
     }>();
   });
 
   test('should select foo.* from foo', () => {
-    expect(toSnap(db.select(star(db.foo)).from(db.foo))).type.toEqual<{
+    expect(toSnap(db.select(star(db.foo)).from(db.foo))).type.toBe<{
       id: string;
       createDate: Date;
       name: string;
@@ -182,7 +182,7 @@ describe('select', () => {
   });
 
   test('should select * from foo', () => {
-    expect(toSnap(db.select(star()).from(db.foo))).type.toEqual<{
+    expect(toSnap(db.select(star()).from(db.foo))).type.toBe<{
       id: string;
       createDate: Date;
       name: string;
@@ -193,7 +193,7 @@ describe('select', () => {
   test('should select * from foo left join bar', () => {
     expect(
       toSnap(db.select(star()).from(db.foo).leftJoin(db.bar).on(db.bar.fooId.eq(db.foo.id))),
-    ).type.toEqual<{
+    ).type.toBe<{
       id: unknown;
       createDate: Date;
       name: string;
@@ -207,7 +207,7 @@ describe('select', () => {
   test('should select * from foo right join bar', () => {
     expect(
       toSnap(db.select(star()).from(db.foo).rightJoin(db.bar).on(db.bar.fooId.eq(db.foo.id))),
-    ).type.toEqual<{
+    ).type.toBe<{
       id: unknown;
       createDate: Date | null;
       name: string | null;
@@ -236,7 +236,7 @@ describe('select', () => {
         () => db.select(db.foo.id, db.foo.createDate, db.foo.name, db.foo.value).from(db.foo),
         ({ test }) => db.select(test.id, test.createDate, test.name, test.value).from(test),
       ),
-    ).type.toEqual<
+    ).type.toBe<
       {
         id: string;
         createDate: Date;
@@ -269,7 +269,7 @@ describe('select', () => {
       await db
         .select(valuesList.id, valuesList.createDate, valuesList.name, valuesList.value)
         .from(valuesList),
-    ).type.toEqual<
+    ).type.toBe<
       {
         id: string;
         createDate: Date;
@@ -296,13 +296,13 @@ describe('select', () => {
           )
           .from(db.foo),
       ),
-    ).type.toEqual<{
+    ).type.toBe<{
       bar: 'A' | 'B' | 'C';
     }>();
   });
 
   test('should select and await result set', async () => {
-    expect(await db.select(db.foo.id, db.foo.value).from(db.foo)).type.toEqual<
+    expect(await db.select(db.foo.id, db.foo.value).from(db.foo)).type.toBe<
       {
         id: string;
         value: number | null;
@@ -313,7 +313,7 @@ describe('select', () => {
   test('should select raw expression', () => {
     expect(
       toSnap(db.select(db.foo.id, raw<number, false, `test`>`test`).from(db.foo)),
-    ).type.toEqual<{
+    ).type.toBe<{
       id: string;
       test: number | null;
     }>();

--- a/src/__checks__/truncate.check.ts
+++ b/src/__checks__/truncate.check.ts
@@ -18,10 +18,10 @@ const db = defineDb({ foo }, () => Promise.resolve({ rows: [], affectedCount: 0 
 
 describe('truncate', () => {
   test('should truncate', () => {
-    expect(toSnap(db.truncate(db.foo))).type.toEqual<never>();
+    expect(toSnap(db.truncate(db.foo))).type.toBeNever();
   });
 
   test('should truncate ans await affected row count', async () => {
-    expect(await db.truncate(db.foo)).type.toEqual<number>();
+    expect(await db.truncate(db.foo)).type.toBeNumber();
   });
 });

--- a/src/__checks__/update.check.ts
+++ b/src/__checks__/update.check.ts
@@ -21,7 +21,7 @@ describe('update', () => {
   test('should update and returning id', () => {
     expect(
       toSnap(db.update(db.foo).set({ name: `Test`, value: 123 }).returning(`id`)),
-    ).type.toEqual<{
+    ).type.toBe<{
       id: string;
     }>();
   });
@@ -29,22 +29,22 @@ describe('update', () => {
   test('should update and returning two columns', () => {
     expect(
       toSnap(db.update(db.foo).set({ name: `Test`, value: 123 }).returning(`id`, `name`)),
-    ).type.toEqual<{
+    ).type.toBe<{
       id: string;
       name: string;
     }>();
   });
 
   test('should update without returning and return number', () => {
-    expect(toSnap(db.update(db.foo).set({ name: `Test`, value: 123 }))).type.toEqual<number>();
+    expect(toSnap(db.update(db.foo).set({ name: `Test`, value: 123 }))).type.toBeNumber();
   });
 
   test('should update and await affected count', async () => {
-    expect(await db.update(db.foo).set({ name: `Test` })).type.toEqual<number>();
+    expect(await db.update(db.foo).set({ name: `Test` })).type.toBeNumber();
   });
 
   test('should update-returning and await rows', async () => {
-    expect(await db.update(db.foo).set({ name: `Test` }).returning(`name`)).type.toEqual<
+    expect(await db.update(db.foo).set({ name: `Test` }).returning(`name`)).type.toBe<
       { name: string }[]
     >();
   });


### PR DESCRIPTION
This PR upgrades TSTyche to v2, which was published recently. 

The new version ships with the watch mode (try it out: `npx tstyche --watch`) and renamed / improved matchers. The detailed release notes can be found here: https://tstyche.org/releases/tstyche-2

I have updated the type tests with the new names accordingly.