### PR TITLE
Add lateral joins

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This fork is based on the 1.x version rather than newer 2.x version.  We made th
 - Changes nullable expressions to use the `null` data type, rather than `undefined`.
 - Fixes `with` query to return the value provided by constructed query.
 - Adds support for constant tables using `VALUES` lists.
+- Adds support for `LATERAL` joins.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@anrok/mammoth",
   "license": "MIT",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "main": "./.build/index.js",
   "types": "./.build/index.d.ts",
   "keywords": [

--- a/src/__tests__/select.test.ts
+++ b/src/__tests__/select.test.ts
@@ -566,6 +566,17 @@ describe(`select`, () => {
     `);
   });
 
+  it(`should select join lateral`, () => {
+    const query = db.select(db.foo.id).from(db.foo).joinLateral(db.bar).on(db.foo.id.eq(db.bar.fooId));
+
+    expect(toSql(query)).toMatchInlineSnapshot(`
+      {
+        "parameters": [],
+        "text": "SELECT foo.id FROM foo JOIN LATERAL bar ON (foo.id = bar.foo_id)",
+      }
+    `);
+  });
+
   it(`should select inner join`, () => {
     const query = db
       .select(db.foo.id)
@@ -577,6 +588,21 @@ describe(`select`, () => {
       {
         "parameters": [],
         "text": "SELECT foo.id FROM foo INNER JOIN bar ON (foo.id = bar.foo_id)",
+      }
+    `);
+  });
+
+  it(`should select inner join lateral`, () => {
+    const query = db
+      .select(db.foo.id)
+      .from(db.foo)
+      .innerJoinLateral(db.bar)
+      .on(db.foo.id.eq(db.bar.fooId));
+
+    expect(toSql(query)).toMatchInlineSnapshot(`
+      {
+        "parameters": [],
+        "text": "SELECT foo.id FROM foo INNER JOIN LATERAL bar ON (foo.id = bar.foo_id)",
       }
     `);
   });
@@ -596,6 +622,21 @@ describe(`select`, () => {
     `);
   });
 
+  it(`should select left outer join lateral`, () => {
+    const query = db
+      .select(db.foo.id)
+      .from(db.foo)
+      .leftOuterJoinLateral(db.bar)
+      .on(db.foo.id.eq(db.bar.fooId));
+
+    expect(toSql(query)).toMatchInlineSnapshot(`
+      {
+        "parameters": [],
+        "text": "SELECT foo.id FROM foo LEFT OUTER JOIN LATERAL bar ON (foo.id = bar.foo_id)",
+      }
+    `);
+  });
+
   it(`should select left join`, () => {
     const query = db.select(db.foo.id).from(db.foo).leftJoin(db.bar).on(db.foo.id.eq(db.bar.fooId));
 
@@ -603,6 +644,17 @@ describe(`select`, () => {
       {
         "parameters": [],
         "text": "SELECT foo.id FROM foo LEFT JOIN bar ON (foo.id = bar.foo_id)",
+      }
+    `);
+  });
+
+  it(`should select left join lateral`, () => {
+    const query = db.select(db.foo.id).from(db.foo).leftJoinLateral(db.bar).on(db.foo.id.eq(db.bar.fooId));
+
+    expect(toSql(query)).toMatchInlineSnapshot(`
+      {
+        "parameters": [],
+        "text": "SELECT foo.id FROM foo LEFT JOIN LATERAL bar ON (foo.id = bar.foo_id)",
       }
     `);
   });

--- a/src/__tests__/select.test.ts
+++ b/src/__tests__/select.test.ts
@@ -582,11 +582,7 @@ describe(`select`, () => {
   });
 
   it(`should select join lateral on true`, () => {
-    const query = db
-      .select(db.foo.id)
-      .from(db.foo)
-      .joinLateral(db.bar)
-      .on(true);
+    const query = db.select(db.foo.id).from(db.foo).joinLateral(db.bar).on(true);
 
     expect(toSql(query)).toMatchInlineSnapshot(`
       {
@@ -594,6 +590,24 @@ describe(`select`, () => {
           true,
         ],
         "text": "SELECT foo.id FROM foo JOIN LATERAL bar ON $1",
+      }
+    `);
+  });
+
+  it(`should select join lateral with alias`, () => {
+    const barSub = db.select(db.bar.id).from(db.bar).as('barSub');
+    const query = db
+      .select(db.foo.id, barSub.id.as('barId'))
+      .from(db.foo)
+      .joinLateral(barSub)
+      .on(true);
+
+    expect(toSql(query)).toMatchInlineSnapshot(`
+      {
+        "parameters": [
+          true,
+        ],
+        "text": "SELECT foo.id, "barSub".id "barId" FROM foo JOIN LATERAL (SELECT bar.id FROM bar) AS barSub ON $1",
       }
     `);
   });

--- a/src/__tests__/select.test.ts
+++ b/src/__tests__/select.test.ts
@@ -581,6 +581,23 @@ describe(`select`, () => {
     `);
   });
 
+  it(`should select join lateral on true`, () => {
+    const query = db
+      .select(db.foo.id)
+      .from(db.foo)
+      .joinLateral(db.bar)
+      .on(true);
+
+    expect(toSql(query)).toMatchInlineSnapshot(`
+      {
+        "parameters": [
+          true,
+        ],
+        "text": "SELECT foo.id FROM foo JOIN LATERAL bar ON $1",
+      }
+    `);
+  });
+
   it(`should select inner join`, () => {
     const query = db
       .select(db.foo.id)

--- a/src/__tests__/select.test.ts
+++ b/src/__tests__/select.test.ts
@@ -567,7 +567,11 @@ describe(`select`, () => {
   });
 
   it(`should select join lateral`, () => {
-    const query = db.select(db.foo.id).from(db.foo).joinLateral(db.bar).on(db.foo.id.eq(db.bar.fooId));
+    const query = db
+      .select(db.foo.id)
+      .from(db.foo)
+      .joinLateral(db.bar)
+      .on(db.foo.id.eq(db.bar.fooId));
 
     expect(toSql(query)).toMatchInlineSnapshot(`
       {
@@ -649,7 +653,11 @@ describe(`select`, () => {
   });
 
   it(`should select left join lateral`, () => {
-    const query = db.select(db.foo.id).from(db.foo).leftJoinLateral(db.bar).on(db.foo.id.eq(db.bar.fooId));
+    const query = db
+      .select(db.foo.id)
+      .from(db.foo)
+      .leftJoinLateral(db.bar)
+      .on(db.foo.id.eq(db.bar.fooId));
 
     expect(toSql(query)).toMatchInlineSnapshot(`
       {

--- a/src/__tests__/select.test.ts
+++ b/src/__tests__/select.test.ts
@@ -67,6 +67,20 @@ describe(`select`, () => {
     `);
   });
 
+  it(`should select star from foo lateral join bar with alias`, () => {
+    const barSub = db.select(db.bar.id.as('barId')).from(db.bar).as('barSub');
+    const query = db.select(star()).from(db.foo).joinLateral(barSub).on(true);
+
+    expect(toSql(query)).toMatchInlineSnapshot(`
+      {
+        "parameters": [
+          true,
+        ],
+        "text": "SELECT foo.id, foo.create_date "createDate", foo.name, foo.value, foo.enum_test "enumTest", "barSub"."barId" "barId" FROM foo JOIN LATERAL (SELECT bar.id "barId" FROM bar) AS "barSub" ON $1",
+      }
+    `);
+  });
+
   it(`should select star plus bar alias from foo`, () => {
     const query = db
       .select(star(), db.bar.id.as(`test`))
@@ -607,7 +621,7 @@ describe(`select`, () => {
         "parameters": [
           true,
         ],
-        "text": "SELECT foo.id, "barSub".id "barId" FROM foo JOIN LATERAL (SELECT bar.id FROM bar) AS barSub ON $1",
+        "text": "SELECT foo.id, "barSub".id "barId" FROM foo JOIN LATERAL (SELECT bar.id FROM bar) AS "barSub" ON $1",
       }
     `);
   });

--- a/src/__tests__/select.test.ts
+++ b/src/__tests__/select.test.ts
@@ -193,6 +193,20 @@ describe(`select`, () => {
     `);
   });
 
+  it(`should select barId from foo lateral join bar with alias`, () => {
+    const barSub = db.select(db.bar.id.as('barId')).from(db.bar).as('barSub');
+    const query = db.select(barSub.barId).from(db.foo).joinLateral(barSub).on(true);
+
+    expect(toSql(query)).toMatchInlineSnapshot(`
+      {
+        "parameters": [
+          true,
+        ],
+        "text": "SELECT "barSub"."barId" "barId" FROM foo JOIN LATERAL (SELECT bar.id "barId" FROM bar) AS "barSub" ON $1",
+      }
+    `);
+  });
+
   it(`should alias a table plus reference it in a condition `, () => {
     const baz = db.foo.as(`baz`);
     const query = db.select(baz.id).from(baz).where(baz.value.eq(1));

--- a/src/select.ts
+++ b/src/select.ts
@@ -15,7 +15,7 @@ import { FromItem } from './with';
 import { Query } from './query';
 import { QueryExecutorFn } from './types';
 import { ResultSet } from './result-set';
-import { Star } from './sql-functions';
+import { isTokenable, Star } from './sql-functions';
 import { Table } from './TableType';
 import { TableDefinition } from './table';
 
@@ -317,11 +317,15 @@ export class SelectQuery<
     return this.tokens;
   }
 
-  on(joinCondition: Expression<boolean, boolean, string>): SelectQuery<Columns, IncludesStar> {
+  on(joinCondition: boolean | Expression<boolean, boolean, string>): SelectQuery<Columns, IncludesStar> {
+    const joinConditionToken = isTokenable(joinCondition)
+      ? new GroupToken(joinCondition.toTokens())
+      : new ParameterToken(joinCondition);
+  
     return this.newSelectQuery([
       ...this.tokens,
       new StringToken(`ON`),
-      new GroupToken(joinCondition.toTokens()),
+      joinConditionToken,
     ]) as any;
   }
 

--- a/src/select.ts
+++ b/src/select.ts
@@ -189,11 +189,27 @@ export class SelectQuery<
     ) as any;
   }
 
+  joinLateral<T extends FromItemOrTable>(table: T): Join<SelectQuery<Columns, IncludesStar>, T> {
+    return this.newSelectQuery(
+      [...this.tokens, new StringToken(`JOIN LATERAL`), ...table.toTokens()],
+      table,
+    ) as any;
+  }
+
   innerJoin<JoinTable extends FromItemOrTable>(
     table: JoinTable,
   ): Join<SelectQuery<Columns, IncludesStar>, JoinTable> {
     return this.newSelectQuery(
       [...this.tokens, new StringToken(`INNER JOIN`), ...table.toTokens()],
+      table,
+    ) as any;
+  }
+
+  innerJoinLateral<JoinTable extends FromItemOrTable>(
+    table: JoinTable,
+  ): Join<SelectQuery<Columns, IncludesStar>, JoinTable> {
+    return this.newSelectQuery(
+      [...this.tokens, new StringToken(`INNER JOIN LATERAL`), ...table.toTokens()],
       table,
     ) as any;
   }
@@ -207,11 +223,29 @@ export class SelectQuery<
     ) as any;
   }
 
+  leftOuterJoinLateral<JoinTable extends FromItemOrTable>(
+    table: JoinTable,
+  ): LeftJoin<SelectQuery<Columns, IncludesStar>, JoinTable> {
+    return this.newSelectQuery(
+      [...this.tokens, new StringToken(`LEFT OUTER JOIN LATERAL`), ...table.toTokens()],
+      table,
+    ) as any;
+  }
+
   leftJoin<JoinTable extends FromItemOrTable>(
     table: JoinTable,
   ): LeftJoin<SelectQuery<Columns, IncludesStar>, JoinTable> {
     return this.newSelectQuery(
       [...this.tokens, new StringToken(`LEFT JOIN`), ...table.toTokens()],
+      table,
+    ) as any;
+  }
+
+  leftJoinLateral<JoinTable extends FromItemOrTable>(
+    table: JoinTable,
+  ): LeftJoin<SelectQuery<Columns, IncludesStar>, JoinTable> {
+    return this.newSelectQuery(
+      [...this.tokens, new StringToken(`LEFT JOIN LATERAL`), ...table.toTokens()],
       table,
     ) as any;
   }

--- a/src/select.ts
+++ b/src/select.ts
@@ -4,6 +4,7 @@ import {
   ParameterToken,
   SeparatorToken,
   StringToken,
+  TableToken,
   Token,
   createQueryState,
 } from './tokens';
@@ -445,7 +446,7 @@ export class SelectQuery<
     return {
       ...makeFromItem(name, this),
       toTokens() {
-        return [new GroupToken(selectTokens), new StringToken(`AS`), new StringToken(name)];
+        return [new GroupToken(selectTokens), new StringToken(`AS`), new TableToken(this)];
       },
     };
   }

--- a/src/with.ts
+++ b/src/with.ts
@@ -445,6 +445,31 @@ export interface WithFn {
   ): Q;
 }
 
+export const makeFromItem = <Q extends Query<any>>(name: string, query: Q): FromItem<Q> => {
+  const fromItem = {
+    ...query.getReturningKeys().reduce((fromItem, key) => {
+      fromItem[key] = new Expression(
+        [new StringToken(`${wrapQuotes(name)}.${wrapQuotes(key)}`)],
+        key,
+      );
+      return fromItem;
+    }, {} as any),
+
+    getName() {
+      return name;
+    },
+
+    getOriginalName() {
+      return undefined;
+    },
+    toTokens() {
+      return [new TableToken(this)];
+    },
+  };
+
+  return fromItem;
+};
+
 export const makeWith =
   (queryExecutor: QueryExecutorFn): WithFn =>
   (...args: any[]) => {
@@ -456,31 +481,6 @@ export const makeWith =
       }
 
       return withFn(queries);
-    };
-
-    const createFromItem = (name: string, query: Query<any>) => {
-      const fromItem = {
-        ...query.getReturningKeys().reduce((fromItem, key) => {
-          fromItem[key] = new Expression(
-            [new StringToken(`${wrapQuotes(name)}.${wrapQuotes(key)}`)],
-            key,
-          );
-          return fromItem;
-        }, {} as any),
-
-        getName() {
-          return name;
-        },
-
-        getOriginalName() {
-          return undefined;
-        },
-        toTokens() {
-          return [new TableToken(this)];
-        },
-      };
-
-      return fromItem;
     };
 
     const tokens: Token[] = [];
@@ -497,7 +497,7 @@ export const makeWith =
         ]),
       );
 
-      queries[name] = createFromItem(name, withQuery);
+      queries[name] = makeFromItem(name, withQuery);
     }
 
     const callback = args[args.length - 1];


### PR DESCRIPTION
This adds lateral join support.

Typically, a lateral join will nest the join conditions inside of the subquery, with an `ON true` clause for the join.  This also adds support for using a boolean with an `ON` clause to handle this use case.

This also adds the ability to give a select query an alias, which converts it into a from item that can be used in other parts of the query with a new name.

`LATERAL` can also be used in a from item, but mammoth currently only supports a single from item, so it wouldn't be useful to support there.  We can re-asses adding `LATERAL` support in from items if we also add multiple from item support.