### PR TITLE
CI: Test on Node 22.x as well

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['18.x', '20.x']
+        node-version: ['18.x', '20.x', '22.x']
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
It's the current release and will become the primary LTS next month.
- https://nodejs.org/en/about/previous-releases