### PR TITLE
remove updating columns to undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@anrok/mammoth",
   "license": "MIT",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "./.build/index.js",
   "types": "./.build/index.d.ts",
   "keywords": [

--- a/src/__tests__/update.test.ts
+++ b/src/__tests__/update.test.ts
@@ -122,4 +122,17 @@ describe(`update`, () => {
       }
     `);
   });
+
+  it(`should not update if value is undefined`, () => {
+    const query = db.update(db.bar).set({ name: undefined, with: `Test` });
+
+    expect(toSql(query)).toMatchInlineSnapshot(`
+      {
+        "parameters": [
+          "Test",
+        ],
+        "text": "UPDATE bar SET "with" = $1",
+      }
+    `);
+  })
 });

--- a/src/__tests__/update.test.ts
+++ b/src/__tests__/update.test.ts
@@ -124,7 +124,7 @@ describe(`update`, () => {
   });
 
   it(`should not update if value is undefined`, () => {
-    const query = db.update(db.bar).set({ name: undefined, with: `Test` });
+    const query = db.update(db.bar).set({});
 
     expect(toSql(query)).toMatchInlineSnapshot(`
       {
@@ -134,5 +134,5 @@ describe(`update`, () => {
         "text": "UPDATE bar SET "with" = $1",
       }
     `);
-  })
+  });
 });

--- a/src/__tests__/update.test.ts
+++ b/src/__tests__/update.test.ts
@@ -124,7 +124,7 @@ describe(`update`, () => {
   });
 
   it(`should not update if value is undefined`, () => {
-    const query = db.update(db.bar).set({});
+    const query = db.update(db.bar).set({ name: undefined, with: `Test` });
 
     expect(toSql(query)).toMatchInlineSnapshot(`
       {

--- a/src/update.ts
+++ b/src/update.ts
@@ -345,7 +345,7 @@ export const makeUpdate =
             }
           : never,
       ): UpdateQuery<T, number> {
-        const keys = Object.keys(values);
+        const keys = Object.keys(values).filter((key) => (values as any)[key] !== undefined);
 
         return new UpdateQuery(queryExecutor, [], table, 'AFFECTED_COUNT', [
           new StringToken(`UPDATE`),

--- a/src/update.ts
+++ b/src/update.ts
@@ -345,7 +345,21 @@ export const makeUpdate =
             }
           : never,
       ): UpdateQuery<T, number> {
-        const keys = Object.keys(values).filter((key) => (values as any)[key] !== undefined);
+        const valuesToken = [];
+        for (const key of Object.keys(values)) {
+          const value = (values as any)[key];
+          if (value === undefined) continue;
+
+          const column = (table as any)[key] as Column<any, any, any, any, any, any>;
+        
+          valuesToken.push(
+            new CollectionToken([
+              new StringToken(wrapQuotes(column.getSnakeCaseName())),
+              new StringToken(`=`),
+              ...(isTokenable(value) ? value.toTokens() : [new ParameterToken(value)]),
+            ]),
+          );
+        }
 
         return new UpdateQuery(queryExecutor, [], table, 'AFFECTED_COUNT', [
           new StringToken(`UPDATE`),
@@ -353,16 +367,7 @@ export const makeUpdate =
           new StringToken(`SET`),
           new SeparatorToken(
             `,`,
-            keys.map((key) => {
-              const column = (table as any)[key] as Column<any, any, any, any, any, any>;
-              const value = (values as any)[key];
-
-              return new CollectionToken([
-                new StringToken(wrapQuotes(column.getSnakeCaseName())),
-                new StringToken(`=`),
-                ...(isTokenable(value) ? value.toTokens() : [new ParameterToken(value)]),
-              ]);
-            }),
+            valuesToken,
           ),
         ]);
       },

--- a/src/update.ts
+++ b/src/update.ts
@@ -351,7 +351,7 @@ export const makeUpdate =
           if (value === undefined) continue;
 
           const column = (table as any)[key] as Column<any, any, any, any, any, any>;
-        
+
           valuesToken.push(
             new CollectionToken([
               new StringToken(wrapQuotes(column.getSnakeCaseName())),
@@ -365,10 +365,7 @@ export const makeUpdate =
           new StringToken(`UPDATE`),
           ...table.toTokens(),
           new StringToken(`SET`),
-          new SeparatorToken(
-            `,`,
-            valuesToken,
-          ),
+          new SeparatorToken(`,`, valuesToken),
         ]);
       },
     };


### PR DESCRIPTION
Fix https://anrok.height.app/T-5138

One of the problems with this fix is that if everything in the set is mapped to undefined, this will create an invalid SQL. 

It will be the equivalent invalid SQL if you write: db.update(db.bar).set({})