### PR TITLE
log undefined ParameterToken creation

### DIFF
--- a/src/tokens/parameter-token.ts
+++ b/src/tokens/parameter-token.ts
@@ -7,7 +7,10 @@ export class ParameterToken extends Token {
     super();
 
     if (parameter === undefined) {
-      console.warn('parameter is undefined. This will likely have unintended consequences.', new Error().stack);
+      console.warn(
+        'parameter is undefined. This will likely have unintended consequences.',
+        new Error().stack,
+      );
     }
 
     this.parameter = parameter;

--- a/src/tokens/parameter-token.ts
+++ b/src/tokens/parameter-token.ts
@@ -6,6 +6,10 @@ export class ParameterToken extends Token {
   constructor(parameter: any) {
     super();
 
+    if (parameter === undefined) {
+      console.warn('parameter is undefined. This will likely have unintended consequences.', new Error().stack);
+    }
+
     this.parameter = parameter;
   }
 


### PR DESCRIPTION
Originally, I planned to have this in DbClientImpl but all stack traces get lost at that point while doing it here will have a stack trace that will at least contain the caller. 