### PR TITLE
fail early if .in takes in an array of length 0

### DIFF
--- a/src/expression.ts
+++ b/src/expression.ts
@@ -162,6 +162,7 @@ export class Expression<DataType, IsNotNull extends boolean, Name extends string
         new GroupToken(array.toTokens()),
       ]);
     } else {
+      assert(array.length > 0, 'Array must have at least one element');
       return new DefaultExpression([
         ...this.tokens,
         new StringToken(`NOT IN`),

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -10,6 +10,7 @@ import {
 
 import { wrapQuotes } from './naming';
 import { isTokenable } from './sql-functions';
+import assert from 'assert';
 
 export class Expression<DataType, IsNotNull extends boolean, Name extends string> {
   private _expressionBrand!: ['expression', DataType, IsNotNull, Name];
@@ -137,6 +138,7 @@ export class Expression<DataType, IsNotNull extends boolean, Name extends string
         new GroupToken(array.toTokens()),
       ]);
     } else {
+      assert(array.length > 0, 'Array must have at least one element');
       return new DefaultExpression([
         ...this.tokens,
         new StringToken(`IN`),

--- a/src/update.ts
+++ b/src/update.ts
@@ -16,6 +16,7 @@ import { Table } from './TableType';
 import { wrapQuotes } from './naming';
 import { FromItem } from './with';
 import { isTokenable } from './sql-functions';
+import assert from 'assert';
 
 // https://www.postgresql.org/docs/12/sql-update.html
 export class UpdateQuery<
@@ -360,6 +361,8 @@ export const makeUpdate =
             ]),
           );
         }
+
+        assert(valuesToken.length > 0, `SET must be setting at least one value.`);
 
         return new UpdateQuery(queryExecutor, [], table, 'AFFECTED_COUNT', [
           new StringToken(`UPDATE`),


### PR DESCRIPTION
when being sent .in with an empty list, this results in a syntax error.

There are no alternative IN query I could make here in postgres that doesn't result in a syntax error.
Fail early so that in those cases, at least the stack trace is better.

Question: I'm using assert here but this code base doesn't have any other asserts. Should I use something else? 