### PR TITLE
Fix how we determine when to quote an alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This fork is based on the 1.x version rather than newer 2.x version.  We made th
 - Fixes `with` query to return the value provided by constructed query.
 - Adds support for constant tables using `VALUES` lists.
 - Adds support for `LATERAL` joins.
+- Fix identifier quoting. Old code wasn't quoting identifiers in all cases: https://github.com/Ff00ff/mammoth/issues/576
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anrok/mammoth",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anrok/mammoth",
-      "version": "0.3.0",
+      "version": "0.3.2",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anrok/mammoth",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anrok/mammoth",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.12",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@anrok/mammoth",
   "license": "MIT",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "main": "./.build/index.js",
   "types": "./.build/index.d.ts",
   "keywords": [

--- a/src/__tests__/select.test.ts
+++ b/src/__tests__/select.test.ts
@@ -1047,13 +1047,37 @@ describe(`select`, () => {
     `);
   });
 
-  it(`should quote name in alias as extended reserved keyword`, () => {
-    const query = db.select(db.foo.id.as(`name`)).from(db.foo);
+  it(`should quote name in alias as extended reserved keyword, but not a table name`, () => {
+    const query = db.select(db.foo.id.as(`name`)).from(db.foo.as(`name`));
 
     expect(toSql(query)).toMatchInlineSnapshot(`
       {
         "parameters": [],
-        "text": "SELECT foo.id "name" FROM foo",
+        "text": "SELECT foo.id "name" FROM foo name",
+      }
+    `);
+  });
+
+  it(`should quote name in alias as extended reserved keyword (more complicated expression)`, () => {
+    const query = db.select(db.foo.id.concat('suffix').as(`name`)).from(db.foo);
+
+    expect(toSql(query)).toMatchInlineSnapshot(`
+      {
+        "parameters": [
+          "suffix",
+        ],
+        "text": "SELECT (foo.id || $1) "name" FROM foo",
+      }
+    `);
+  });
+
+  it(`should quote non-snake-case name`, () => {
+    const query = db.select(db.foo.id.as(`1234`), db.foo.id.as(`?column?`)).from(db.foo.as(`1234`));
+
+    expect(toSql(query)).toMatchInlineSnapshot(`
+      {
+        "parameters": [],
+        "text": "SELECT foo.id \"1234\", foo.id \"?column?\" FROM foo \"1234\"",
       }
     `);
   });

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -364,7 +364,7 @@ export class Expression<DataType, IsNotNull extends boolean, Name extends string
     if (includeAlias && (this.nameIsAlias || this.name.match(/[A-Z]/))) {
       // Some expression return a train_case name by default such as string_agg. We automatically
       // convert these to camelCase equivalents e.g. stringAgg.
-      return [...this.tokens, new StringToken(`${wrapQuotes(this.name)}`)];
+      return [...this.tokens, new StringToken(wrapQuotes(this.name, true))];
     }
 
     return this.tokens;

--- a/src/naming/all-reserved-keywords.ts
+++ b/src/naming/all-reserved-keywords.ts
@@ -1,3 +1,5 @@
+// All keywords listed in https://www.postgresql.org/docs/12/sql-keywords-appendix.html
+// Includes reserved, non-reserved, and others.
 export const allReservedKeywords = new Set([
   'a',
   'abort',

--- a/src/naming/index.ts
+++ b/src/naming/index.ts
@@ -1,10 +1,14 @@
 import { allReservedKeywords } from './all-reserved-keywords';
 import { reservedKeywords } from './reserved-keywords';
 
+// More restrictive than strictly necessary, so we'll end up quoting some things that don't
+// necessarily need quotes, but that's fine.
+const validIdentifierRe = /^[a-z_][a-z0-9_]*$/;
+
 export const wrapQuotes = (string: string, extended?: boolean) => {
-  const isCamelCase = string.match(/[A-Z]/);
+  const isValidIdentifier = validIdentifierRe.test(string);
   const isReserved = reservedKeywords.has(string) || (extended && allReservedKeywords.has(string));
-  const shouldWrap = isReserved || isCamelCase;
+  const shouldWrap = isReserved || !isValidIdentifier;
 
   return shouldWrap ? `"${string}"` : string;
 };

--- a/src/update.ts
+++ b/src/update.ts
@@ -355,7 +355,7 @@ export const makeUpdate =
 
           valuesToken.push(
             new CollectionToken([
-              new StringToken(wrapQuotes(column.getSnakeCaseName())),
+              new StringToken(column.getSnakeCaseName()),
               new StringToken(`=`),
               ...(isTokenable(value) ? value.toTokens() : [new ParameterToken(value)]),
             ]),


### PR DESCRIPTION
- For simple column aliases, we checked extended keywords. But for more complex expressions, we didn't.
- In all cases, the only "weird" characters we checked for were capital letters.

(The weird characters issue was filed on the original project a while ago: https://github.com/Ff00ff/mammoth/issues/576)