### PR TITLE
Revert "log undefined ParameterToken creation"

### DIFF
--- a/src/tokens/parameter-token.ts
+++ b/src/tokens/parameter-token.ts
@@ -6,13 +6,6 @@ export class ParameterToken extends Token {
   constructor(parameter: any) {
     super();
 
-    if (parameter === undefined) {
-      console.warn(
-        'parameter is undefined. This will likely have unintended consequences.',
-        new Error().stack,
-      );
-    }
-
     this.parameter = parameter;
   }
 


### PR DESCRIPTION
Reverts Anrok/mammoth#22

parameter token of undefined can be used when inserting default values. 