### PR TITLE
Add ability to getDefinition from a column

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This fork is based on the 1.x version rather than newer 2.x version.  We made th
 - Adds support for constant tables using `VALUES` lists.
 - Adds support for `LATERAL` joins.
 - Fix identifier quoting. Old code wasn't quoting identifiers in all cases: https://github.com/Ff00ff/mammoth/issues/576
-- Adds ability to get a column's definition from a column.
+- `Column` objects now contain a reference to their `ColumnDefinition`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This fork is based on the 1.x version rather than newer 2.x version.  We made th
 - Adds support for constant tables using `VALUES` lists.
 - Adds support for `LATERAL` joins.
 - Fix identifier quoting. Old code wasn't quoting identifiers in all cases: https://github.com/Ff00ff/mammoth/issues/576
+- Adds ability to get a column's definition from a column.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@anrok/mammoth",
   "license": "MIT",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "main": "./.build/index.js",
   "types": "./.build/index.d.ts",
   "keywords": [

--- a/src/__tests__/ddl.test.ts
+++ b/src/__tests__/ddl.test.ts
@@ -18,6 +18,24 @@ describe(`ddl`, () => {
     () => Promise.resolve({ rows: [], affectedCount: 0 }),
   );
 
+  it('should retrieve column definition info from column', () => {
+    const column = db.foo.id;
+    expect(column.getDefinition().getDefinition()).toMatchInlineSnapshot(`
+      {
+        "checkExpression": undefined,
+        "dataType": "uuid",
+        "defaultExpression": "gen_random_uuid()",
+        "enumValues": undefined,
+        "isNotNull": false,
+        "isPrimaryKey": true,
+        "isUnique": false,
+        "referencesColumn": undefined,
+        "referencesSelf": false,
+        "referencesTable": undefined,
+      }
+    `);
+  })
+
   it(`should retrieve column definition info`, () => {
     const tableDefinitions = db.getTableDefinitions();
 

--- a/src/__tests__/ddl.test.ts
+++ b/src/__tests__/ddl.test.ts
@@ -34,7 +34,7 @@ describe(`ddl`, () => {
         "referencesTable": undefined,
       }
     `);
-  })
+  });
 
   it(`should retrieve column definition info`, () => {
     const tableDefinitions = db.getTableDefinitions();

--- a/src/column.ts
+++ b/src/column.ts
@@ -160,7 +160,13 @@ export class Column<
     return this.columnName;
   }
 
+  /** @internal */
+  getDefinition() {
+    return this.definition;
+  }
+
   constructor(
+    private readonly definition: ColumnDefinition<DataType, IsNotNull, HasDefault>,
     private readonly columnName: Name,
     private readonly tableName: TableName,
     private readonly originalColumnName: string | undefined,
@@ -188,7 +194,7 @@ export class Column<
   as<AliasName extends string>(
     alias: AliasName,
   ): Column<AliasName, TableName, DataType, IsNotNull, HasDefault, JoinType> {
-    return new Column(alias, this.tableName, this.columnName as unknown as string);
+    return new Column(this.definition, alias, this.tableName, this.columnName as unknown as string);
   }
 
   /** @internal */

--- a/src/table.ts
+++ b/src/table.ts
@@ -31,13 +31,19 @@ export const makeTable = <
   originalTableName: string | undefined,
   tableDefinition: TableDefinition,
 ) => {
-  const columnEntries = Object.entries(
-    tableDefinition as unknown as object,
-  ) as [(keyof TableDefinition), ColumnDefinition<any, any, any>][];
+  const columnEntries = Object.entries(tableDefinition as unknown as object) as [
+    keyof TableDefinition,
+    ColumnDefinition<any, any, any>,
+  ][];
 
   const columns = columnEntries.reduce(
     (map, [columnName, columnDefinition]) => {
-      const column = new Column(columnDefinition, columnName as string, tableName, undefined) as any;
+      const column = new Column(
+        columnDefinition,
+        columnName as string,
+        tableName,
+        undefined,
+      ) as any;
       map[columnName] = column;
       return map;
     },

--- a/src/table.ts
+++ b/src/table.ts
@@ -31,13 +31,13 @@ export const makeTable = <
   originalTableName: string | undefined,
   tableDefinition: TableDefinition,
 ) => {
-  const columnNames = Object.keys(
+  const columnEntries = Object.entries(
     tableDefinition as unknown as object,
-  ) as (keyof TableDefinition)[];
+  ) as [(keyof TableDefinition), ColumnDefinition<any, any, any>][];
 
-  const columns = columnNames.reduce(
-    (map, columnName) => {
-      const column = new Column(columnName as string, tableName, undefined) as any;
+  const columns = columnEntries.reduce(
+    (map, [columnName, columnDefinition]) => {
+      const column = new Column(columnDefinition, columnName as string, tableName, undefined) as any;
       map[columnName] = column;
       return map;
     },

--- a/src/values.ts
+++ b/src/values.ts
@@ -34,13 +34,19 @@ export function makeValues<
   tableDefinition: TableDefinitionT,
   values: Array<TableRow<TableDefinition<TableDefinitionT>>>,
 ): Table<TableName, ColumnDefinitionsToColumns<TableName, TableDefinitionT>> {
-  const columnEntries = Object.entries(
-    tableDefinition as unknown as object,
-  ) as [(keyof TableDefinitionT), ColumnDefinition<any, any, any>][];
+  const columnEntries = Object.entries(tableDefinition as unknown as object) as [
+    keyof TableDefinitionT,
+    ColumnDefinition<any, any, any>,
+  ][];
 
   const columns = columnEntries.reduce(
     (map, [columnName, columnDefinition]) => {
-      const column = new Column(columnDefinition, columnName as string, tableName, undefined) as any;
+      const column = new Column(
+        columnDefinition,
+        columnName as string,
+        tableName,
+        undefined,
+      ) as any;
       map[columnName] = column;
       return map;
     },
@@ -83,16 +89,16 @@ export function makeValues<
                   new SeparatorToken(
                     ',',
                     columnEntries.map(([columnName, columnDefinition]) => {
-                      const columnValueToken = new ParameterToken((value as any)[columnName] as any);
+                      const columnValueToken = new ParameterToken(
+                        (value as any)[columnName] as any,
+                      );
 
                       if (index === 0) {
                         // Cast on the first row only to ensure correct types in the list.
                         return new CollectionToken([
                           columnValueToken,
                           new StringToken('::'),
-                          new StringToken(
-                            columnDefinition.getDefinition().dataType,
-                          ),
+                          new StringToken(columnDefinition.getDefinition().dataType),
                         ]);
                       }
 
@@ -108,7 +114,9 @@ export function makeValues<
         new GroupToken([
           new SeparatorToken(
             ',',
-            columnEntries.map(([columnName]) => new StringToken(`"${toSnakeCase(columnName as string)}"`)),
+            columnEntries.map(
+              ([columnName]) => new StringToken(`"${toSnakeCase(columnName as string)}"`),
+            ),
           ),
         ]),
       ];


### PR DESCRIPTION
At runtime, it is useful to be able to fetch a column's definition to have access to the data type, non-nullability, default values, etc.  This change the `Column` class to store a reference to its definition.  The definition is accessible via a `getDefinition` function.