### PR TITLE
Adds support for SELECT DISTINCT

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This fork is based on the 1.x version rather than newer 2.x version.  We made th
 - Adds support for `LATERAL` joins.
 - Fix identifier quoting. Old code wasn't quoting identifiers in all cases: https://github.com/Ff00ff/mammoth/issues/576
 - `Column` objects now contain a reference to their `ColumnDefinition`.
+- Adds support for `SELECT DISTINCT`.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@anrok/mammoth",
   "license": "MIT",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "main": "./.build/index.js",
   "types": "./.build/index.d.ts",
   "keywords": [

--- a/src/__tests__/select.test.ts
+++ b/src/__tests__/select.test.ts
@@ -136,6 +136,17 @@ describe(`select`, () => {
     `);
   });
 
+  it(`should select distinct foo`, () => {
+    const query = db.selectDistinct(db.foo.id).from(db.foo);
+
+    expect(toSql(query)).toMatchInlineSnapshot(`
+      {
+        "parameters": [],
+        "text": "SELECT DISTINCT foo.id FROM foo",
+      }
+    `);
+  });
+
   it(`should select camel case table`, () => {
     const query = db.select(db.listItem.id).from(db.listItem);
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -72,7 +72,7 @@ export const defineDb = <TableDefinitions extends { [key: string]: TableDefiniti
       });
     },
     select: makeSelect(queryExecutor),
-    selectDistinct: makeSelect(queryExecutor, [], true),
+    selectDistinct: makeSelect(queryExecutor, [], { isDistinct: true }),
     insertInto: makeInsertInto(queryExecutor),
     deleteFrom: makeDeleteFrom(queryExecutor),
     update: makeUpdate(queryExecutor),

--- a/src/db.ts
+++ b/src/db.ts
@@ -72,6 +72,7 @@ export const defineDb = <TableDefinitions extends { [key: string]: TableDefiniti
       });
     },
     select: makeSelect(queryExecutor),
+    selectDistinct: makeSelect(queryExecutor, [], true),
     insertInto: makeInsertInto(queryExecutor),
     deleteFrom: makeDeleteFrom(queryExecutor),
     update: makeUpdate(queryExecutor),

--- a/src/select.ts
+++ b/src/select.ts
@@ -453,7 +453,7 @@ export class SelectQuery<
 }
 
 export const makeSelect =
-  (queryExecutor: QueryExecutorFn, initialTokens?: Token[]): SelectFn =>
+  (queryExecutor: QueryExecutorFn, initialTokens?: Token[], distinct?: boolean): SelectFn =>
   <T extends Selectable>(...columns: T[]) => {
     const includesStar = !!columns.find((column) => column instanceof Star);
 
@@ -473,7 +473,7 @@ export const makeSelect =
 
     return new SelectQuery(queryExecutor, returningKeys, includesStar, [
       ...(initialTokens || []),
-      new StringToken(`SELECT`),
+      new StringToken(distinct === true ? `SELECT DISTINCT` : 'SELECT'),
       new SeparatorToken(
         `,`,
         columns.map((column) => {

--- a/src/select.ts
+++ b/src/select.ts
@@ -453,7 +453,11 @@ export class SelectQuery<
 }
 
 export const makeSelect =
-  (queryExecutor: QueryExecutorFn, initialTokens?: Token[], distinct?: boolean): SelectFn =>
+  (
+    queryExecutor: QueryExecutorFn,
+    initialTokens?: Token[],
+    { isDistinct = false }: { isDistinct?: boolean } = {},
+  ): SelectFn =>
   <T extends Selectable>(...columns: T[]) => {
     const includesStar = !!columns.find((column) => column instanceof Star);
 
@@ -473,7 +477,7 @@ export const makeSelect =
 
     return new SelectQuery(queryExecutor, returningKeys, includesStar, [
       ...(initialTokens || []),
-      new StringToken(distinct === true ? `SELECT DISTINCT` : 'SELECT'),
+      new StringToken(isDistinct === true ? `SELECT DISTINCT` : 'SELECT'),
       new SeparatorToken(
         `,`,
         columns.map((column) => {


### PR DESCRIPTION
This adds support for `SELECT DISTINCT`.  It adds a `selectDistinct` function to `db`, and uses the same `makeSelect` function as `select`, but with an optional parameter to add the `DISTINCT` token.