### PR TITLE
withComment support for SELECT and UPDATE (variant of #31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This fork is based on the 1.x version rather than newer 2.x version.  We made th
 - Fix identifier quoting. Old code wasn't quoting identifiers in all cases: https://github.com/Ff00ff/mammoth/issues/576
 - `Column` objects now contain a reference to their `ColumnDefinition`.
 - Adds support for `SELECT DISTINCT`.
+- Adds support for adding comments to the front of queries.
 
 ---
 

--- a/src/__tests__/comment.test.ts
+++ b/src/__tests__/comment.test.ts
@@ -1,0 +1,94 @@
+import { defineDb, defineTable, integer, text, timestampWithTimeZone, toSql, uuid } from '..';
+
+describe(`comment`, () => {
+  const foo = defineTable({
+    id: uuid().primaryKey().default(`gen_random_uuid()`),
+    createDate: timestampWithTimeZone().notNull().default(`now()`),
+    name: text().notNull(),
+    value: integer(),
+  });
+
+  const bar = defineTable({
+    id: uuid().primaryKey().default(`gen_random_uuid()`),
+    fooId: uuid().notNull().references(foo, `id`),
+    name: text(),
+    with: text(),
+  });
+
+  const db = defineDb({ foo, bar }, () => Promise.resolve({ rows: [], affectedCount: 0 }));
+
+  it(`select`, () => {
+    const query = db
+      .comment('This is a comment')
+      .select(db.bar.id)
+      .from(db.bar)
+      .where(db.bar.name.eq('Test'));
+
+    expect(toSql(query)).toStrictEqual({
+      parameters: ['Test'],
+      text: '/*This is a comment*/ SELECT bar.id FROM bar WHERE bar.name = $1',
+    });
+  });
+
+  it(`update`, () => {
+    const query = db.comment('This is a comment').update(db.bar).set({ name: `Test` });
+
+    expect(toSql(query)).toStrictEqual({
+      parameters: ['Test'],
+      text: '/*This is a comment*/ UPDATE bar SET name = $1',
+    });
+  });
+
+  it(`insert`, () => {
+    const query = db
+      .comment('This is a comment')
+      .insertInto(db.foo)
+      .values([
+        {
+          name: `Test`,
+        },
+        {
+          name: `Test 2`,
+        },
+      ]);
+
+    expect(toSql(query)).toEqual({
+      parameters: ['Test', 'Test 2'],
+      text: '/*This is a comment*/ INSERT INTO foo (name) VALUES ($1), ($2)',
+    });
+  });
+
+  it(`update`, () => {
+    const query = db
+      .comment('This is a comment')
+      .update(db.foo)
+      .set({ name: `Test` })
+      .from(db.bar)
+      .where(db.bar.fooId.eq(db.foo.id).and(db.bar.name.isNotNull()));
+
+    expect(toSql(query)).toStrictEqual({
+      parameters: ['Test'],
+      text: '/*This is a comment*/ UPDATE foo SET name = $1 FROM bar WHERE bar.foo_id = foo.id AND bar.name IS NOT NULL',
+    });
+  });
+
+  it(`with`, () => {
+    const query = db.with(
+      'a',
+      db.comment('A').select(db.bar.id).from(db.bar).where(db.bar.name.eq('TestA')),
+      'b',
+      db.comment('B').select(db.foo.name).from(db.foo).where(db.foo.id.eq('TestB')),
+      ({ a, b }) => db.comment('C').select(a.id, b.name).from(a).join(b),
+    );
+
+    expect(toSql(query)).toStrictEqual({
+      parameters: ['TestA', 'TestB'],
+      text: [
+        '/*C*/ WITH',
+        'a AS (/*A*/ SELECT bar.id FROM bar WHERE bar.name = $1),',
+        'b AS (/*B*/ SELECT foo.name FROM foo WHERE foo.id = $2)',
+        'SELECT a.id, b.name FROM a JOIN b',
+      ].join(' '),
+    });
+  });
+});

--- a/src/query.ts
+++ b/src/query.ts
@@ -2,7 +2,7 @@
 // specify every query seperately. The private property is used to simulate a nominal type so only
 import { ResultSet } from './result-set';
 import { Token } from './tokens';
-import { DbNull } from './types';
+import { DbNull, QueryExecutorFn } from './types';
 
 export type SpecificQuery<DataType, Q extends Query<any>, Result = ResultSet<Q>> = Result extends {
   [K in keyof Result]: DataType | DbNull;
@@ -15,8 +15,15 @@ export type BooleanQuery<Q extends Query<any>> = SpecificQuery<boolean, Q>;
 // this class is captured when doing a conditional type check (through T extends Query<infer Returning>).
 export abstract class Query<Returning> {
   private _queryBrand!: ['query', Returning];
+  protected constructor(
+    protected readonly queryExecutor: QueryExecutorFn,
+    protected readonly commentTokens: Token[],
+  ) {}
   /** @internal */
-  abstract toTokens(includeAlias?: boolean): Token[];
+  toTokens(includeAlias?: boolean): Token[] {
+    return [...this.commentTokens, ...this.toQueryTokens(includeAlias)];
+  }
+  abstract toQueryTokens(includeAlias?: boolean): Token[];
   /** @internal */
   abstract getReturningKeys(): string[];
 

--- a/src/truncate.ts
+++ b/src/truncate.ts
@@ -6,11 +6,11 @@ import { Table } from './TableType';
 import { TableDefinition } from './table';
 
 export const makeTruncate =
-  (queryExecutor: QueryExecutorFn) =>
+  (queryExecutor: QueryExecutorFn, commentTokens: Token[]) =>
   <T extends Table<any, any>>(
     table: T,
   ): T extends TableDefinition<any> ? never : TruncateQuery<T> => {
-    return new TruncateQuery<T>(queryExecutor, table, 'AFFECTED_COUNT', [
+    return new TruncateQuery<T>(queryExecutor, commentTokens, table, 'AFFECTED_COUNT', [
       new StringToken(`TRUNCATE`),
       new StringToken((table as Table<any, any>).getName()),
     ]) as any;
@@ -23,16 +23,23 @@ export class TruncateQuery<
 > extends Query<Returning> {
   /** @internal */
   newQueryWithTokens(tokens: Array<Token>): TruncateQuery<T, Returning, TableColumns> {
-    return new TruncateQuery(this.queryExecutor, this.table, this.resultType, tokens);
+    return new TruncateQuery(
+      this.queryExecutor,
+      this.commentTokens,
+      this.table,
+      this.resultType,
+      tokens,
+    );
   }
 
   constructor(
-    private readonly queryExecutor: QueryExecutorFn,
+    queryExecutor: QueryExecutorFn,
+    commentTokens: Token[],
     private readonly table: T,
     private readonly resultType: ResultType,
     private readonly tokens: Token[],
   ) {
-    super();
+    super(queryExecutor, commentTokens);
   }
 
   then<Result1, Result2 = never>(
@@ -66,7 +73,7 @@ export class TruncateQuery<
     return [];
   }
 
-  toTokens(): Token[] {
+  toQueryTokens(): Token[] {
     return this.tokens;
   }
 }

--- a/src/with.ts
+++ b/src/with.ts
@@ -1,17 +1,19 @@
 import {
   CollectionToken,
+  createQueryState,
   GroupToken,
   SeparatorToken,
   StringToken,
   TableToken,
   Token,
 } from './tokens';
-import { GetDataType, QueryExecutorFn } from './types';
+import { GetDataType, QueryExecutorFn, ResultType } from './types';
 
 import { Expression } from './expression';
 import { Query } from './query';
 import { CapturingResultSet } from './result-set';
 import { wrapQuotes } from './naming';
+import { Table } from './TableType';
 
 export type FromItem<Q> =
   Q extends Query<any>
@@ -471,7 +473,7 @@ export const makeFromItem = <Q extends Query<any>>(name: string, query: Q): From
 };
 
 export const makeWith =
-  (queryExecutor: QueryExecutorFn): WithFn =>
+  (): WithFn =>
   (...args: any[]) => {
     const queries: any = {};
 
@@ -507,6 +509,6 @@ export const makeWith =
     return query.newQueryWithTokens([
       new StringToken(`WITH`),
       new SeparatorToken(`,`, tokens),
-      ...query.toTokens(),
+      ...query.toQueryTokens(),
     ]);
   };


### PR DESCRIPTION
This implementation seem simpler, since it uses the same mechanism that the other methods use to modify the query. Does this have any issues? (It seems to pass the two simple tests that you added, but I'm not sure if there are other cases it doesn't handle.)