### PR TITLE
chore: update TSTyche to v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "jest": "^29.7.0",
         "prettier": "^3.4.2",
         "ts-jest": "^29.2.5",
-        "tstyche": "^2.1.1",
+        "tstyche": "^4.3.0",
         "typescript": "^5.7.3"
       }
     },
@@ -3649,22 +3649,22 @@
       }
     },
     "node_modules/tstyche": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tstyche/-/tstyche-2.1.1.tgz",
-      "integrity": "sha512-SvAukLfHk894rbBJEu6+7S9ZggN89FDe4VA0xT/mldW7gmqcpmNV7+OghlR2IZyUbkas4mjrjOKxSWZ3IQzV+w==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/tstyche/-/tstyche-4.3.0.tgz",
+      "integrity": "sha512-X5mSVCivhCSDKHr9tWfCH0kmEo5cLApZILK5XfssTIirc9wEvcSYhCaixj5TSR/39cIC7U5TQD+wtGKsYh7nlw==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "tstyche": "build/bin.js"
       },
       "engines": {
-        "node": ">=16.14"
+        "node": ">=20.9"
       },
       "funding": {
         "url": "https://github.com/tstyche/tstyche?sponsor=1"
       },
       "peerDependencies": {
-        "typescript": "4.x || 5.x"
+        "typescript": ">=4.7"
       },
       "peerDependenciesMeta": {
         "typescript": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "jest": "^29.7.0",
     "prettier": "^3.4.2",
     "ts-jest": "^29.2.5",
-    "tstyche": "^2.1.1",
+    "tstyche": "^4.3.0",
     "typescript": "^5.7.3"
   },
   "scripts": {

--- a/src/__checks__/data-types.check.ts
+++ b/src/__checks__/data-types.check.ts
@@ -75,8 +75,6 @@ const toSnap = <T extends Query<any>>(query: T): ResultSet<T> => {
   return undefined as any;
 };
 
-/** @dts-jest enable:test-type */
-
 const foo = defineTable({
   id: uuid().primaryKey().default(`gen_random_uuid()`),
   int8: int8(),

--- a/src/__checks__/delete.check.ts
+++ b/src/__checks__/delete.check.ts
@@ -22,7 +22,7 @@ describe('delete', () => {
   });
 
   test('should delete and await affected row count', async () => {
-    expect(await db.deleteFrom(db.foo)).type.toBeNumber();
+    expect(await db.deleteFrom(db.foo)).type.toBe<number>();
   });
 
   test('should delete and await rows', async () => {

--- a/src/__checks__/insert.check.ts
+++ b/src/__checks__/insert.check.ts
@@ -35,37 +35,38 @@ const db = defineDb({ foo, serialTest }, () => Promise.resolve({ rows: [], affec
 
 describe('insert', () => {
   test('should insert and returning count', () => {
-    expect(toSnap(db.insertInto(db.foo).values({ name: `Test` }))).type.toBeNumber();
+    expect(toSnap(db.insertInto(db.foo).values({ name: `Test` }))).type.toBe<number>();
   });
 
   test('should insert multiple rows and returning count', () => {
     expect(
       toSnap(db.insertInto(db.foo).values([{ name: `Test` }, { name: `Test 2` }])),
-    ).type.toBeNumber();
+    ).type.toBe<number>();
   });
 
   test('should insert default column', () => {
     expect(
       toSnap(db.insertInto(db.foo).values({ name: `Test`, createDate: new Date() })),
-    ).type.toBeNumber();
+    ).type.toBe<number>();
   });
 
   test('should not insert unknown column', () => {
-    expect(toSnap(db.insertInto(db.foo).values({ name: `Test`, asd: `Test` }))).type.toRaiseError();
+    expect(db.insertInto(db.foo).values).type.not.toBeCallableWith({ name: `Test`, asd: `Test` });
   });
 
   test('should not insert invalid type in known column', () => {
-    expect(toSnap(db.insertInto(db.foo).values({ name: 123 }))).type.toRaiseError();
+    expect(db.insertInto(db.foo).values).type.not.toBeCallableWith({ name: 123 });
   });
 
   test('should not insert multiple rows with invalid colums', () => {
-    expect(
-      toSnap(db.insertInto(db.foo).values([{ name: `Test` }, { name: `Test 2`, asd: 123 }])),
-    ).type.toRaiseError();
+    expect(db.insertInto(db.foo).values).type.not.toBeCallableWith([
+      { name: `Test` },
+      { name: `Test 2`, asd: 123 },
+    ]);
   });
 
   test('should insert and await affect count', async () => {
-    expect(await db.insertInto(db.foo).values({ name: `Test` })).type.toBeNumber();
+    expect(await db.insertInto(db.foo).values({ name: `Test` })).type.toBe<number>();
   });
 
   test('should insert-returning and await rows', async () => {
@@ -136,9 +137,9 @@ describe('insert', () => {
   });
 
   test('should not insert with wrong type of expression', () => {
-    expect(
-      db.insertInto(db.serialTest).values({ value: raw<string>`get_value()` }),
-    ).type.toRaiseError();
+    expect(db.insertInto(db.serialTest).values).type.not.toBeCallableWith({
+      value: raw<string>`get_value()`,
+    });
   });
 
   test('should insert using subquery', () => {

--- a/src/__checks__/select.check.ts
+++ b/src/__checks__/select.check.ts
@@ -215,14 +215,7 @@ describe('select', () => {
   });
 
   test('should not use in with wrong data type', () => {
-    expect(
-      toSnap(
-        db
-          .select(db.foo.id)
-          .from(db.foo)
-          .where(db.foo.id.in(db.select(db.foo.createDate).from(db.foo))),
-      ),
-    ).type.toRaiseError();
+    expect(db.foo.id.in).type.not.toBeCallableWith(db.select(db.foo.createDate).from(db.foo));
   });
 
   test('with test as select from foo from test', async () => {

--- a/src/__checks__/truncate.check.ts
+++ b/src/__checks__/truncate.check.ts
@@ -18,10 +18,10 @@ const db = defineDb({ foo }, () => Promise.resolve({ rows: [], affectedCount: 0 
 
 describe('truncate', () => {
   test('should truncate', () => {
-    expect(toSnap(db.truncate(db.foo))).type.toBeNever();
+    expect(toSnap(db.truncate(db.foo))).type.toBe<never>();
   });
 
   test('should truncate ans await affected row count', async () => {
-    expect(await db.truncate(db.foo)).type.toBeNumber();
+    expect(await db.truncate(db.foo)).type.toBe<number>();
   });
 });

--- a/src/__checks__/tsconfig.json
+++ b/src/__checks__/tsconfig.json
@@ -1,8 +1,8 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"types": ["node"]
-	},
-	"include": ["**/*"],
-	"exclude": []
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["**/*"],
+  "exclude": []
 }

--- a/src/__checks__/tsconfig.json
+++ b/src/__checks__/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "types": ["node"]
   },
-  "include": ["**/*"],
+  "include": ["."],
   "exclude": []
 }

--- a/src/__checks__/tsconfig.json
+++ b/src/__checks__/tsconfig.json
@@ -1,5 +1,8 @@
 {
-  "extends": "../../tsconfig.json",
-  "include": ["./*.check.ts"],
-  "exclude": []
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"types": ["node"]
+	},
+	"include": ["**/*"],
+	"exclude": []
 }

--- a/src/__checks__/update.check.ts
+++ b/src/__checks__/update.check.ts
@@ -34,11 +34,11 @@ describe('update', () => {
   });
 
   test('should update without returning and return number', () => {
-    expect(toSnap(db.update(db.foo).set({ name: `Test`, value: 123 }))).type.toBeNumber();
+    expect(toSnap(db.update(db.foo).set({ name: `Test`, value: 123 }))).type.toBe<number>();
   });
 
   test('should update and await affected count', async () => {
-    expect(await db.update(db.foo).set({ name: `Test` })).type.toBeNumber();
+    expect(await db.update(db.foo).set({ name: `Test` })).type.toBe<number>();
   });
 
   test('should update-returning and await rows', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -67,5 +67,5 @@
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   },
   "include": ["src"],
-  "exclude": ["src/__checks__/**", "src/__tests__/**"]
+  "exclude": ["src/__checks__", "src/__tests__"]
 }

--- a/tstyche.config.json
+++ b/tstyche.config.json
@@ -1,3 +1,6 @@
 {
-  "testFileMatch": ["**/__checks__/*.check.ts"]
+	"$schema": "https://tstyche.org/schemas/config.json",
+	"checkSuppressedErrors": true,
+	"checkSourceFiles": false,
+	"testFileMatch": ["src/__checks__/*.check.ts"]
 }

--- a/tstyche.config.json
+++ b/tstyche.config.json
@@ -1,6 +1,6 @@
 {
-	"$schema": "https://tstyche.org/schemas/config.json",
-	"checkSuppressedErrors": true,
-	"checkSourceFiles": false,
-	"testFileMatch": ["src/__checks__/*.check.ts"]
+  "$schema": "https://tstyche.org/schemas/config.json",
+  "checkSuppressedErrors": true,
+  "checkSourceFiles": false,
+  "testFileMatch": ["src/__checks__/*.check.ts"]
 }


### PR DESCRIPTION
This PR updates TSTyche to the latest version.

There are two notable changes:

- matchers like `.toBeNumber()` are removed in favour of simply `.toBe<number>()`
- a new `.toBeCallableWith()` matcher is added; here I used `.not.toBeCallableWith()` instead of `.toRaiseError()` which is planned to be removed