### PR TITLE
[RFC] support materialized CTE

### DIFF
--- a/src/__tests__/execute.test.ts
+++ b/src/__tests__/execute.test.ts
@@ -157,9 +157,4 @@ describe(`execute`, () => {
       ]
     `);
   });
-
-  it('with materialized test', async () => {
-    d
-  })
-
 });

--- a/src/__tests__/execute.test.ts
+++ b/src/__tests__/execute.test.ts
@@ -157,4 +157,9 @@ describe(`execute`, () => {
       ]
     `);
   });
+
+  it('with materialized test', async () => {
+    d
+  })
+
 });

--- a/src/__tests__/with.test.ts
+++ b/src/__tests__/with.test.ts
@@ -1,4 +1,5 @@
 import { defineDb, defineTable, integer, star, sum, text, toSql, uuid } from '..';
+import { MaterializedCTE } from '../with';
 
 describe(`with`, () => {
   const orderLog = defineTable({
@@ -112,4 +113,45 @@ describe(`with`, () => {
       }
     `);
   });
+
+  it(`should work with materialized settings`, () => {
+    const query = db.with(
+      [`regionalSales`, MaterializedCTE.materialized],
+      () =>
+        db
+          .select(db.orderLog.region, sum(db.orderLog.amount).as(`totalSales`))
+          .from(db.orderLog)
+          .groupBy(db.orderLog.region),
+      [`topRegions`, MaterializedCTE.notMaterialized],
+      ({ regionalSales }) =>
+        db
+          .select(regionalSales.region)
+          .from(regionalSales)
+          .where(
+            regionalSales.totalSales.gt(
+              db.select(sum(regionalSales.totalSales).divide(10)).from(regionalSales),
+            ),
+          ),
+      ({ topRegions }) =>
+        db
+          .select(
+            db.orderLog.region,
+            db.orderLog.product,
+            sum(db.orderLog.quantity).as(`productUnits`),
+            sum(db.orderLog.amount).as(`productSales`),
+          )
+          .from(db.orderLog)
+          .where(db.orderLog.region.in(db.select(topRegions.region).from(topRegions)))
+          .groupBy(db.orderLog.region, db.orderLog.product),
+    );
+
+    expect(toSql(query)).toMatchInlineSnapshot(`
+      {
+        "parameters": [
+          10,
+        ],
+        "text": "WITH "regionalSales" AS (SELECT order_log.region, SUM (order_log.amount) "totalSales" FROM order_log GROUP BY order_log.region), "topRegions" AS (SELECT "regionalSales".region FROM "regionalSales" WHERE "regionalSales"."totalSales" > (SELECT SUM ("regionalSales"."totalSales") / $1 FROM "regionalSales")) SELECT order_log.region, order_log.product, SUM (order_log.quantity) "productUnits", SUM (order_log.amount) "productSales" FROM order_log WHERE order_log.region IN (SELECT "topRegions".region FROM "topRegions") GROUP BY order_log.region, order_log.product",
+      }
+    `);
+  })
 });


### PR DESCRIPTION
https://www.postgresql.org/docs/current/queries-with.html#QUERIES-WITH-CTE-MATERIALIZATION

CTE materialization is needed because we can make use of this feature to form optimization boundaries to make queries perform better.

This is an initial idea to do this. 

One big downside of doing this is that we need to do something about the method signature of WithFn.