### PR TITLE
Extract FromItem and makeFromItem into from-item.ts

### DIFF
--- a/src/delete.ts
+++ b/src/delete.ts
@@ -15,7 +15,7 @@ import type { ResultSet } from './result-set';
 import type { Table } from './TableType';
 import type { TableDefinition } from './table';
 import { wrapQuotes } from './naming';
-import { FromItem } from './with';
+import { FromItem } from './from-item';
 
 export const makeDeleteFrom =
   (queryExecutor: QueryExecutorFn, commentTokens: Token[]) =>

--- a/src/from-item.ts
+++ b/src/from-item.ts
@@ -1,0 +1,49 @@
+import { StringToken, TableToken, Token } from './tokens';
+import { GetDataType } from './types';
+
+import { Expression } from './expression';
+import { Query } from './query';
+import { CapturingResultSet } from './result-set';
+import { wrapQuotes } from './naming';
+
+export type FromItem<Q> =
+  Q extends Query<any>
+    ? FromItemQuery<Q>
+    : Q extends (args: any) => infer R
+      ? R extends Query<any>
+        ? FromItemQuery<R>
+        : never
+      : never;
+
+type FromItemQuery<Q, Result = Q extends Query<any> ? CapturingResultSet<Q> : never> = {
+  toTokens: () => Array<Token>;
+} & {
+  [K in keyof Result]: Result[K] extends GetDataType<infer DataType, infer IsNotNull>
+    ? Expression<DataType, IsNotNull, K extends string ? K : never>
+    : never;
+};
+
+export const makeFromItem = <Q extends Query<any>>(name: string, query: Q): FromItem<Q> => {
+  const fromItem = {
+    ...query.getReturningKeys().reduce((fromItem, key) => {
+      fromItem[key] = new Expression(
+        [new StringToken(`${wrapQuotes(name)}.${wrapQuotes(key)}`)],
+        key,
+      );
+      return fromItem;
+    }, {} as any),
+
+    getName() {
+      return name;
+    },
+
+    getOriginalName() {
+      return undefined;
+    },
+    toTokens() {
+      return [new TableToken(this)];
+    },
+  };
+
+  return fromItem;
+};

--- a/src/select.ts
+++ b/src/select.ts
@@ -12,7 +12,7 @@ import { SelectFn, Selectable } from './SelectFn';
 
 import { Column } from './column';
 import { Expression } from './expression';
-import { FromItem, makeFromItem } from './with';
+import { FromItem, makeFromItem } from './from-item';
 import { Query } from './query';
 import { QueryExecutorFn } from './types';
 import { ResultSet } from './result-set';

--- a/src/update.ts
+++ b/src/update.ts
@@ -14,7 +14,7 @@ import { Query } from './query';
 import { ResultSet } from './result-set';
 import { Table } from './TableType';
 import { wrapQuotes } from './naming';
-import { FromItem } from './with';
+import { FromItem } from './from-item';
 import { isTokenable } from './sql-functions';
 import assert from 'assert';
 

--- a/src/with.ts
+++ b/src/with.ts
@@ -1,34 +1,13 @@
-import {
-  CollectionToken,
-  GroupToken,
-  SeparatorToken,
-  StringToken,
-  TableToken,
-  Token,
-} from './tokens';
-import { GetDataType } from './types';
+import { CollectionToken, GroupToken, SeparatorToken, StringToken, Token } from './tokens';
 
-import { Expression } from './expression';
 import { Query } from './query';
-import { CapturingResultSet } from './result-set';
 import { wrapQuotes } from './naming';
+import { FromItem, makeFromItem } from './from-item';
 
-export type FromItem<Q> =
-  Q extends Query<any>
-    ? FromItemQuery<Q>
-    : Q extends (args: any) => infer R
-      ? R extends Query<any>
-        ? FromItemQuery<R>
-        : never
-      : never;
-
-type FromItemQuery<Q, Result = Q extends Query<any> ? CapturingResultSet<Q> : never> = {
-  toTokens: () => Array<Token>;
-} & {
-  [K in keyof Result]: Result[K] extends GetDataType<infer DataType, infer IsNotNull>
-    ? Expression<DataType, IsNotNull, K extends string ? K : never>
-    : never;
-};
+/** @deprecated Import from `./from-item` instead. */
+export type { FromItem } from './from-item';
+/** @deprecated Import from `./from-item` instead. */
+export { makeFromItem } from './from-item';
 
 type QueryFn<T> = Query<any> | ((args: T) => Query<any>);
 
@@ -587,31 +566,6 @@ export interface WithFn {
     ) => Q,
   ): Q;
 }
-
-export const makeFromItem = <Q extends Query<any>>(name: string, query: Q): FromItem<Q> => {
-  const fromItem = {
-    ...query.getReturningKeys().reduce((fromItem, key) => {
-      fromItem[key] = new Expression(
-        [new StringToken(`${wrapQuotes(name)}.${wrapQuotes(key)}`)],
-        key,
-      );
-      return fromItem;
-    }, {} as any),
-
-    getName() {
-      return name;
-    },
-
-    getOriginalName() {
-      return undefined;
-    },
-    toTokens() {
-      return [new TableToken(this)];
-    },
-  };
-
-  return fromItem;
-};
 
 export const makeWith =
   (): WithFn =>


### PR DESCRIPTION
`FromItem` and `makeFromItem` are in "with.ts", but they're not specific to that file. For example, they're used in "select.ts" as well. Move those definitions to their own file, "from-item.ts".

This is in preparation for a larger change to fix the way LEFT JOIN works, which makes some changes to `FromItem` and `makeFromItem`. Landing this first will make that change easier to read.