### PR TITLE
Fix left join nullability in subquery and CTE column references

### DIFF
--- a/src/TableType.ts
+++ b/src/TableType.ts
@@ -7,8 +7,7 @@ export interface InternalTable<TableName, Columns> {
   /** @internal */
   _tableBrand: any;
 
-  /** @internal */
-  getName(): string;
+  getName(): TableName;
 
   /** @internal */
   getOriginalName(): string | undefined;

--- a/src/__checks__/select.check.ts
+++ b/src/__checks__/select.check.ts
@@ -305,4 +305,71 @@ describe('select', () => {
       test: number | null;
     }>();
   });
+
+  test('should not make CTE columns nullable when left joining another table', async () => {
+    // CTE columns are on the outer (left) side — they must stay non-nullable
+    expect(
+      await db.with(
+        `cte`,
+        () => db.select(db.foo.id, db.foo.name).from(db.foo),
+        ({ cte }) =>
+          db.select(cte.id, cte.name, db.bar.endDate).from(cte).leftJoin(db.bar).on(true),
+      ),
+    ).type.toBe<
+      {
+        id: string;
+        name: string; // NOT NULL — CTE column on outer side must stay non-nullable
+        endDate: Date | null; // bar.endDate is nullable after left join
+      }[]
+    >();
+  });
+
+  test('should return nullable columns from CTE when left joining', async () => {
+    expect(
+      await db.with(
+        'cte',
+        () => db.select(db.foo.name).from(db.foo),
+        ({ cte }) => db.select(db.bar.startDate, cte.name).from(db.bar).leftJoin(cte).on(true),
+      ),
+    ).type.toBe<
+      {
+        startDate: Date;
+        name: string | null;
+      }[]
+    >();
+  });
+
+  test('should return nullable columns from subquery when left joining', () => {
+    // NOT NULL column in subquery (name) should become nullable after left join
+    // Already nullable column in subquery (value) should remain nullable
+    const sub = db.select(db.foo.name, db.foo.value).from(db.foo).limit(1).as('sub');
+    expect(
+      toSnap(db.select(db.bar.startDate, sub.name, sub.value).from(db.bar).leftJoin(sub).on(true)),
+    ).type.toBe<{
+      startDate: Date;
+      name: string | null;
+      value: number | null;
+    }>();
+  });
+
+  test('should not make outer columns nullable when left joining a subquery', () => {
+    // db.bar.startDate is from the left (outer) table — should stay non-nullable
+    const sub = db.select(db.foo.name).from(db.foo).limit(1).as('sub');
+    expect(
+      toSnap(db.select(db.bar.startDate, sub.name).from(db.bar).leftJoin(sub).on(true)),
+    ).type.toBe<{
+      startDate: Date;
+      name: string | null;
+    }>();
+  });
+
+  test('should make aliased subquery column nullable when left joining', () => {
+    const sub = db.select(db.foo.name).from(db.foo).limit(1).as('sub');
+    expect(
+      toSnap(db.select(db.bar.startDate, sub.name.as('n')).from(db.bar).leftJoin(sub).on(true)),
+    ).type.toBe<{
+      startDate: Date;
+      n: string | null;
+    }>();
+  });
 });

--- a/src/__checks__/select.check.ts
+++ b/src/__checks__/select.check.ts
@@ -14,9 +14,20 @@ import {
   uuid,
 } from '../';
 
+import { Column } from '../column';
+import { FromItem } from '../from-item';
 import { Query } from '../query';
 import { ResultSet } from '../result-set';
+import { SelectQuery } from '../select';
 import { expect, describe, test } from 'tstyche';
+
+// Extracts the Columns record type from a SelectQuery.
+// Used to inspect column types (e.g. Column vs ColumnExpression) after joins.
+function getColumnsType<Cols extends { [column: string]: any }, Inc extends boolean>(
+  _: SelectQuery<Cols, Inc>,
+): Cols {
+  return undefined as any;
+}
 
 const toSnap = <T extends Query<any>>(query: T): ResultSet<T> => {
   return undefined as any;
@@ -371,5 +382,32 @@ describe('select', () => {
       startDate: Date;
       n: string | null;
     }>();
+  });
+
+  test('named subquery should be assignable to FromItem without a name parameter', () => {
+    // A function accepting a generic (unnamed) FromItem — typical in helper functions
+    // that receive a subquery but don't care about its alias.
+    const q = db.select(db.foo.name, db.foo.value).from(db.foo).limit(1);
+    const sub = q.as('sub');
+    const acceptsUnnamed = (fromItem: FromItem<typeof q>) => fromItem;
+    expect(acceptsUnnamed(sub)).type.not.toRaiseError();
+  });
+
+  test('Column TableName is a structural member — columns from different tables are not interchangeable', () => {
+    // ColumnExpression carries TableName as `protected readonly tableName`, so
+    // Column<N, T1, ...> and Column<N, T2, ...> are structurally distinct when T1 ≠ T2.
+    // Before ColumnExpression was introduced, TableName was phantom-only and any two
+    // Column instances with the same Name/DataType/IsNotNull were interchangeable.
+    //
+    // Code that passed a column aliased from one table where a column from a different
+    // table was expected now gets a type error. This test guards against regressions
+    // that would silently restore the old phantom behaviour.
+    const acceptsFooId = (_: Column<'id', 'foo', string, true, boolean, undefined>) => {};
+
+    // foo.id is Column<'id', 'foo', ...> — accepted.
+    expect(acceptsFooId(db.foo.id)).type.not.toRaiseError();
+
+    // bar.fooId aliased to 'id' is Column<'id', 'bar', ...> — rejected: wrong TableName.
+    expect(acceptsFooId(db.bar.fooId.as('id'))).type.toRaiseError();
   });
 });

--- a/src/__tests__/select.test.ts
+++ b/src/__tests__/select.test.ts
@@ -733,6 +733,25 @@ describe(`select`, () => {
     `);
   });
 
+  it(`should select left join with subquery alias and explicit columns`, () => {
+    const fooSub = db.select(db.foo.name, db.foo.value).from(db.foo).limit(1).as('fooSub');
+    const query = db
+      .select(db.bar.id, fooSub.name, fooSub.value)
+      .from(db.bar)
+      .leftJoin(fooSub)
+      .on(true);
+
+    expect(toSql(query)).toMatchInlineSnapshot(`
+      {
+        "parameters": [
+          1,
+          true,
+        ],
+        "text": "SELECT bar.id, "fooSub".name, "fooSub".value FROM bar LEFT JOIN (SELECT foo.name, foo.value FROM foo LIMIT $1) AS "fooSub" ON $2",
+      }
+    `);
+  });
+
   it(`should select right outer join`, () => {
     const query = db.select(db.foo.id).from(db.foo).rightOuterJoin(db.bar).using(db.foo.id);
 

--- a/src/column.ts
+++ b/src/column.ts
@@ -130,6 +130,38 @@ export const makeColumnDefinition = <
   };
 };
 
+// Base class for any typed column reference — either a table column (Column) or a
+// subquery/CTE column reference. Carries TableName and JoinType as type parameters
+// so join logic in select.ts and result-set.ts can treat both uniformly.
+export class ColumnExpression<
+  Name extends string,
+  TableName,
+  DataType,
+  IsNotNull extends boolean,
+  JoinType = never,
+> extends Expression<DataType, IsNotNull, Name> {
+  constructor(
+    tokens: Token[],
+    protected readonly columnName: Name,
+    protected readonly tableName: TableName,
+    protected readonly originalColumnName: string | undefined,
+  ) {
+    super(tokens, columnName, originalColumnName !== undefined);
+  }
+
+  as<NewName extends string>(
+    name: NewName,
+  ): ColumnExpression<NewName, TableName, DataType, IsNotNull, JoinType> {
+    const sqlName = this.originalColumnName ?? this.columnName;
+    return new ColumnExpression<NewName, TableName, DataType, IsNotNull, JoinType>(
+      [new StringToken(`${wrapQuotes(this.tableName as string)}.${wrapQuotes(sqlName)}`)],
+      name,
+      this.tableName,
+      sqlName,
+    );
+  }
+}
+
 // This is only used as a nominal type, not actually as an instance.
 export class ColumnSet<Columns> {
   private _columnSetBrand: any;
@@ -146,10 +178,8 @@ export class Column<
   DataType,
   IsNotNull extends boolean,
   HasDefault extends boolean,
-  JoinType,
-> extends Expression<DataType, IsNotNull, Name> {
-  private _columnBrand: any;
-
+  JoinType = never,
+> extends ColumnExpression<Name, TableName, DataType, IsNotNull, JoinType> {
   /** @internal */
   getSnakeCaseName() {
     return wrapQuotes(toSnakeCase(this.columnName));
@@ -167,31 +197,25 @@ export class Column<
 
   constructor(
     private readonly definition: ColumnDefinition<DataType, IsNotNull, HasDefault>,
-    private readonly columnName: Name,
-    private readonly tableName: TableName,
-    private readonly originalColumnName: string | undefined,
+    columnName: Name,
+    tableName: TableName,
+    originalColumnName: string | undefined,
   ) {
     super(
-      originalColumnName
-        ? [
-            new StringToken(
-              `${wrapQuotes(tableName as unknown as string)}.${wrapQuotes(
-                toSnakeCase(originalColumnName),
-              )}`,
-            ),
-          ]
-        : [
-            new StringToken(
-              `${wrapQuotes(tableName as unknown as string)}.${wrapQuotes(
-                toSnakeCase(columnName),
-              )}`,
-            ),
-          ],
-      columnName as any,
+      [
+        new StringToken(
+          `${wrapQuotes(tableName as unknown as string)}.${wrapQuotes(
+            toSnakeCase(originalColumnName ?? columnName),
+          )}`,
+        ),
+      ],
+      columnName,
+      tableName,
+      originalColumnName,
     );
   }
 
-  as<AliasName extends string>(
+  override as<AliasName extends string>(
     alias: AliasName,
   ): Column<AliasName, TableName, DataType, IsNotNull, HasDefault, JoinType> {
     return new Column(this.definition, alias, this.tableName, this.columnName as unknown as string);

--- a/src/from-item.ts
+++ b/src/from-item.ts
@@ -6,9 +6,9 @@ import { Query } from './query';
 import { CapturingResultSet } from './result-set';
 import { wrapQuotes } from './naming';
 
-// Use the literal name when captured; never otherwise (prevents false matches
-// when the name isn't known at compile time).
-type CapturedName<Name extends string> = string extends Name ? never : Name;
+// Use the literal name when captured; string otherwise (allows named subqueries
+// to be assigned to FromItem without a name parameter).
+type CapturedName<Name extends string> = string extends Name ? string : Name;
 
 export type FromItem<Q, Name extends string = string> =
   Q extends Query<any>

--- a/src/from-item.ts
+++ b/src/from-item.ts
@@ -1,34 +1,47 @@
 import { StringToken, TableToken, Token } from './tokens';
 import { GetDataType } from './types';
 
-import { Expression } from './expression';
+import { ColumnExpression } from './column';
 import { Query } from './query';
 import { CapturingResultSet } from './result-set';
 import { wrapQuotes } from './naming';
 
-export type FromItem<Q> =
+// Use the literal name when captured; never otherwise (prevents false matches
+// when the name isn't known at compile time).
+type CapturedName<Name extends string> = string extends Name ? never : Name;
+
+export type FromItem<Q, Name extends string = string> =
   Q extends Query<any>
-    ? FromItemQuery<Q>
+    ? FromItemQuery<Q, Name>
     : Q extends (args: any) => infer R
       ? R extends Query<any>
-        ? FromItemQuery<R>
+        ? FromItemQuery<R, Name>
         : never
       : never;
 
-type FromItemQuery<Q, Result = Q extends Query<any> ? CapturingResultSet<Q> : never> = {
+type FromItemQuery<
+  Q,
+  Name extends string = string,
+  Result = Q extends Query<any> ? CapturingResultSet<Q> : never,
+> = {
   toTokens: () => Array<Token>;
 } & {
   [K in keyof Result]: Result[K] extends GetDataType<infer DataType, infer IsNotNull>
-    ? Expression<DataType, IsNotNull, K extends string ? K : never>
+    ? ColumnExpression<K extends string ? K : never, CapturedName<Name>, DataType, IsNotNull>
     : never;
 };
 
-export const makeFromItem = <Q extends Query<any>>(name: string, query: Q): FromItem<Q> => {
+export const makeFromItem = <Q extends Query<any>, Name extends string = string>(
+  name: Name,
+  query: Q,
+): FromItem<Q, Name> => {
   const fromItem = {
     ...query.getReturningKeys().reduce((fromItem, key) => {
-      fromItem[key] = new Expression(
+      fromItem[key] = new ColumnExpression(
         [new StringToken(`${wrapQuotes(name)}.${wrapQuotes(key)}`)],
         key,
+        name,
+        undefined,
       );
       return fromItem;
     }, {} as any),

--- a/src/result-set.ts
+++ b/src/result-set.ts
@@ -1,4 +1,4 @@
-import type { Column } from './column';
+import type { ColumnExpression } from './column';
 import { DeleteQuery } from './delete';
 import type { Expression } from './expression';
 import { DbNull, Expand, GetDataType } from './types';
@@ -21,12 +21,11 @@ type MaybeCapturingResultSetDataType<
 > = ShouldCapture extends true ? GetDataType<Type, IsNotNull> : ResultSetDataType<Type, IsNotNull>;
 
 type MaybeCapturingReturningResultSet<Returning, ShouldCapture extends boolean> = {
-  [K in keyof Returning]: Returning[K] extends Column<
+  [K in keyof Returning]: Returning[K] extends ColumnExpression<
     any,
     any,
     infer D,
     infer N,
-    any,
     infer JoinType
   >
     ? Extract<JoinType, 'left-join'> extends never

--- a/src/select.ts
+++ b/src/select.ts
@@ -10,7 +10,7 @@ import {
 } from './tokens';
 import { SelectFn, Selectable } from './SelectFn';
 
-import { Column } from './column';
+import { Column, ColumnExpression } from './column';
 import { Expression } from './expression';
 import { FromItem, makeFromItem } from './from-item';
 import { Query } from './query';
@@ -28,26 +28,33 @@ type ToJoinType<OldType, NewType extends JoinType> =
 
 // It's important to note that to make sure we infer the table name, we should pass object instead
 // of any as the second argument to the table.
-type GetTableName<T extends Table<any, any>> = T extends Table<infer A, object> ? A : never;
+// For FromItem, return the literal alias when available; never otherwise.
+type GetTableName<T> =
+  T extends Table<infer A, object>
+    ? A
+    : T extends FromItem<any, infer Name>
+      ? string extends Name
+        ? never
+        : Name
+      : never;
 
 type FromItemOrTable = FromItem<any> | Table<string, unknown>;
 
-// Extracts the source name (table name) from a Column. Used alongside GetTableName to check
-// whether a column belongs to a particular join target.
-type SourceOf<T> = T extends Column<any, infer TableName, any, any, any, any> ? TableName : never;
+// Extracts the relation name (table name or subquery alias) from any ColumnExpression.
+// Used alongside GetTableName to check whether a column belongs to a join target.
+type SourceOf<T> =
+  T extends ColumnExpression<any, infer TableName, any, any, any> ? TableName : never;
 
-// Applies a join-type transformation to a Column by setting its JoinType parameter,
-// which result-set.ts resolves to nullable.
+// Applies a join-type transformation to any ColumnExpression.
 type ApplyJoinType<T, J extends JoinType> =
-  T extends Column<
+  T extends ColumnExpression<
     infer Name,
     infer TableName,
     infer DataType,
     infer IsNotNull,
-    infer HasDefault,
     infer OldJoinType
   >
-    ? Column<Name, TableName, DataType, IsNotNull, HasDefault, ToJoinType<OldJoinType, J>>
+    ? ColumnExpression<Name, TableName, DataType, IsNotNull, ToJoinType<OldJoinType, J>>
     : never;
 
 type AddLeftJoin<Columns, JoinTable> = {
@@ -434,7 +441,7 @@ export class SelectQuery<
     return this.newSelectQuery([...this.tokens, new StringToken(`SKIP LOCKED`)]);
   }
 
-  as(name: string): FromItem<SelectQuery<Columns>> {
+  as<Name extends string>(name: Name): FromItem<SelectQuery<Columns>, Name> {
     const selectTokens = this.tokens;
     return {
       ...makeFromItem(name, this),

--- a/src/select.ts
+++ b/src/select.ts
@@ -38,14 +38,13 @@ type GetTableName<T> =
         : Name
       : never;
 
-type FromItemOrTable = FromItem<any> | Table<string, unknown>;
+type FromItemOrTable = FromItem<any> | Table<unknown, unknown>;
 
 // Extracts the relation name (table name or subquery alias) from any ColumnExpression.
 // Used alongside GetTableName to check whether a column belongs to a join target.
 type SourceOf<T> =
   T extends ColumnExpression<any, infer TableName, any, any, any> ? TableName : never;
 
-// Applies a join-type transformation to any ColumnExpression.
 type ApplyJoinType<T, J extends JoinType> =
   T extends ColumnExpression<
     infer Name,

--- a/src/with.ts
+++ b/src/with.ts
@@ -5,9 +5,7 @@ import { wrapQuotes } from './naming';
 import { FromItem, makeFromItem } from './from-item';
 
 /** @deprecated Import from `./from-item` instead. */
-export type { FromItem } from './from-item';
-/** @deprecated Import from `./from-item` instead. */
-export { makeFromItem } from './from-item';
+export { FromItem, makeFromItem } from './from-item';
 
 type QueryFn<T> = Query<any> | ((args: T) => Query<any>);
 
@@ -19,7 +17,7 @@ type GetNameFromNameAndMaterialization<NM> = NM extends string
     : never;
 
 type WithArg<N extends NameAndMaterialization, W> = {
-  [K in GetNameFromNameAndMaterialization<N>]: FromItem<W>;
+  [K in GetNameFromNameAndMaterialization<N>]: FromItem<W, GetNameFromNameAndMaterialization<N>>;
 };
 
 export interface WithFn {


### PR DESCRIPTION
Table columns used `Column` and CTE/subquery columns used `Expression`. But `Expression` didn't track enough (e.g. the relation name) to do LEFT JOIN correctly.

Introduce something in between, `ColumnExpression`, which has enough to do LEFT JOIN correctly, but doesn't require everything that a table column has. Use that for CTE/subquery columns.