### PR TITLE
use literal values for booleans instead of parameterizing them to improve postgresql plan output

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This fork is based on the 1.x version rather than newer 2.x version.  We made th
 - Make .in(...) and .notIn(...) accept read-only arrays as well.
 - Add support for `MATERIALIZED` and `NOT MATERIALIZED` modifier on CTEs.
 - Add an explicit `.execute()` method. It's not necessary, but using it results in better stack traces.
+- Boolean values passed into expression-building APIs (e.g. `column.eq(true)`, `column.in([true, false])`, `joinLateral(...).on(true)`, `case().when(...).then(true)`, `coalesce(col, false)`) are now rendered as the SQL literals `TRUE` / `FALSE` instead of being bound as parameters. This lets the Postgres planner fold the predicate / pick a partial index, which it cannot do for a bind parameter. Booleans in `INSERT VALUES` and `UPDATE SET` are still parameterized so prepared statements can be reused across rows.
+- Add a `literal()` helper for inlining `number` and `bigint` values into SQL instead of binding them as parameters. Same use case as the boolean change above, but opt-in for numeric types because inlining them pollutes the plan cache.
 
 ---
 

--- a/src/__tests__/select.test.ts
+++ b/src/__tests__/select.test.ts
@@ -955,10 +955,7 @@ describe(`select`, () => {
   });
 
   it(`should auto-inline a true boolean value in a where clause`, () => {
-    const query = db
-      .select(db.listItem.id)
-      .from(db.listItem)
-      .where(db.listItem.isGreat.eq(true));
+    const query = db.select(db.listItem.id).from(db.listItem).where(db.listItem.isGreat.eq(true));
 
     expect(toSql(query)).toMatchInlineSnapshot(`
       {
@@ -969,10 +966,7 @@ describe(`select`, () => {
   });
 
   it(`should auto-inline a false boolean value in a where clause`, () => {
-    const query = db
-      .select(db.listItem.id)
-      .from(db.listItem)
-      .where(db.listItem.isGreat.eq(false));
+    const query = db.select(db.listItem.id).from(db.listItem).where(db.listItem.isGreat.eq(false));
 
     expect(toSql(query)).toMatchInlineSnapshot(`
       {
@@ -1010,7 +1004,10 @@ describe(`select`, () => {
       }
     `);
 
-    const inlined = db.select(db.foo.id).from(db.foo).where(db.foo.value.gt(literal(0)));
+    const inlined = db
+      .select(db.foo.id)
+      .from(db.foo)
+      .where(db.foo.value.gt(literal(0)));
 
     expect(toSql(inlined)).toMatchInlineSnapshot(`
       {

--- a/src/__tests__/select.test.ts
+++ b/src/__tests__/select.test.ts
@@ -1,4 +1,4 @@
-import { raw, star, toSql } from '../sql-functions';
+import { literal, raw, star, toSql } from '../sql-functions';
 import {
   any,
   arrayAgg,
@@ -72,12 +72,10 @@ describe(`select`, () => {
     const query = db.select(star()).from(db.foo).joinLateral(barSub).on(true);
 
     expect(toSql(query)).toMatchInlineSnapshot(`
-      {
-        "parameters": [
-          true,
-        ],
-        "text": "SELECT foo.id, foo.create_date "createDate", foo.name, foo.value, foo.enum_test "enumTest", "barSub"."barId" "barId" FROM foo JOIN LATERAL (SELECT bar.id "barId" FROM bar) AS "barSub" ON $1",
-      }
+     {
+       "parameters": [],
+       "text": "SELECT foo.id, foo.create_date "createDate", foo.name, foo.value, foo.enum_test "enumTest", "barSub"."barId" "barId" FROM foo JOIN LATERAL (SELECT bar.id "barId" FROM bar) AS "barSub" ON TRUE",
+     }
     `);
   });
 
@@ -209,12 +207,10 @@ describe(`select`, () => {
     const query = db.select(barSub.barId).from(db.foo).joinLateral(barSub).on(true);
 
     expect(toSql(query)).toMatchInlineSnapshot(`
-      {
-        "parameters": [
-          true,
-        ],
-        "text": "SELECT "barSub"."barId" "barId" FROM foo JOIN LATERAL (SELECT bar.id "barId" FROM bar) AS "barSub" ON $1",
-      }
+     {
+       "parameters": [],
+       "text": "SELECT "barSub"."barId" "barId" FROM foo JOIN LATERAL (SELECT bar.id "barId" FROM bar) AS "barSub" ON TRUE",
+     }
     `);
   });
 
@@ -620,12 +616,10 @@ describe(`select`, () => {
     const query = db.select(db.foo.id).from(db.foo).joinLateral(db.bar).on(true);
 
     expect(toSql(query)).toMatchInlineSnapshot(`
-      {
-        "parameters": [
-          true,
-        ],
-        "text": "SELECT foo.id FROM foo JOIN LATERAL bar ON $1",
-      }
+     {
+       "parameters": [],
+       "text": "SELECT foo.id FROM foo JOIN LATERAL bar ON TRUE",
+     }
     `);
   });
 
@@ -638,12 +632,10 @@ describe(`select`, () => {
       .on(true);
 
     expect(toSql(query)).toMatchInlineSnapshot(`
-      {
-        "parameters": [
-          true,
-        ],
-        "text": "SELECT foo.id, "barSub".id "barId" FROM foo JOIN LATERAL (SELECT bar.id FROM bar) AS "barSub" ON $1",
-      }
+     {
+       "parameters": [],
+       "text": "SELECT foo.id, "barSub".id "barId" FROM foo JOIN LATERAL (SELECT bar.id FROM bar) AS "barSub" ON TRUE",
+     }
     `);
   });
 
@@ -960,6 +952,82 @@ describe(`select`, () => {
         "text": "SELECT list_item.id FROM list_item WHERE list_item.is_great",
       }
     `);
+  });
+
+  it(`should auto-inline a true boolean value in a where clause`, () => {
+    const query = db
+      .select(db.listItem.id)
+      .from(db.listItem)
+      .where(db.listItem.isGreat.eq(true));
+
+    expect(toSql(query)).toMatchInlineSnapshot(`
+      {
+        "parameters": [],
+        "text": "SELECT list_item.id FROM list_item WHERE list_item.is_great = TRUE",
+      }
+    `);
+  });
+
+  it(`should auto-inline a false boolean value in a where clause`, () => {
+    const query = db
+      .select(db.listItem.id)
+      .from(db.listItem)
+      .where(db.listItem.isGreat.eq(false));
+
+    expect(toSql(query)).toMatchInlineSnapshot(`
+      {
+        "parameters": [],
+        "text": "SELECT list_item.id FROM list_item WHERE list_item.is_great = FALSE",
+      }
+    `);
+  });
+
+  it(`should auto-inline booleans in IN clauses while still parameterizing strings`, () => {
+    const query = db
+      .select(db.listItem.id)
+      .from(db.listItem)
+      .where(db.listItem.isGreat.in([true, false]).and(db.listItem.name.eq(`example`)));
+
+    expect(toSql(query)).toMatchInlineSnapshot(`
+      {
+        "parameters": [
+          "example",
+        ],
+        "text": "SELECT list_item.id FROM list_item WHERE list_item.is_great IN (TRUE, FALSE) AND list_item.name = $1",
+      }
+    `);
+  });
+
+  it(`should still parameterize numbers by default (use literal() to opt in)`, () => {
+    const parametrized = db.select(db.foo.id).from(db.foo).where(db.foo.value.gt(0));
+
+    expect(toSql(parametrized)).toMatchInlineSnapshot(`
+      {
+        "parameters": [
+          0,
+        ],
+        "text": "SELECT foo.id FROM foo WHERE foo.value > $1",
+      }
+    `);
+
+    const inlined = db.select(db.foo.id).from(db.foo).where(db.foo.value.gt(literal(0)));
+
+    expect(toSql(inlined)).toMatchInlineSnapshot(`
+      {
+        "parameters": [],
+        "text": "SELECT foo.id FROM foo WHERE foo.value > 0",
+      }
+    `);
+  });
+
+  it(`should reject non-finite numeric literals`, () => {
+    expect(() => literal(Number.NaN)).toThrow(/non-finite/);
+    expect(() => literal(Number.POSITIVE_INFINITY)).toThrow(/non-finite/);
+  });
+
+  it(`should reject unsupported literal types at runtime`, () => {
+    expect(() => (literal as any)(`hello`)).toThrow(/only supports/);
+    expect(() => (literal as any)(null)).toThrow(/only supports/);
   });
 
   it(`should select with case and else`, () => {

--- a/src/case.ts
+++ b/src/case.ts
@@ -1,5 +1,5 @@
 import { BooleanQuery, Query } from './query';
-import { ParameterToken, StringToken, Token } from './tokens';
+import { expressionValueToken, StringToken, Token } from './tokens';
 
 import { Expression } from './expression';
 
@@ -15,7 +15,7 @@ export class CaseStatement<DataType> {
           new StringToken(`WHEN`),
           ...expression.toTokens(),
           new StringToken(`THEN`),
-          new ParameterToken(result),
+          expressionValueToken(result),
         ]);
       },
     };
@@ -25,7 +25,7 @@ export class CaseStatement<DataType> {
     return new CaseStatement<DataType | T>([
       ...this.tokens,
       new StringToken(`ELSE`),
-      new ParameterToken(result),
+      expressionValueToken(result),
     ]);
   }
 

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -1,8 +1,8 @@
 import { BooleanQuery, Query, SpecificQuery } from './query';
 import {
   CollectionToken,
+  expressionValueToken,
   GroupToken,
-  ParameterToken,
   SeparatorToken,
   StringToken,
   Token,
@@ -42,7 +42,7 @@ export class Expression<DataType, IsNotNull extends boolean, Name extends string
       return value.toTokens();
     }
 
-    return [new ParameterToken(value)];
+    return [expressionValueToken(value)];
   }
 
   private toGroup(expression: Expression<any, any, any> | Query<any>) {
@@ -148,7 +148,7 @@ export class Expression<DataType, IsNotNull extends boolean, Name extends string
         new GroupToken([
           new SeparatorToken(
             ',',
-            array.map((item) => new ParameterToken(item)),
+            array.map((item) => expressionValueToken(item)),
           ),
         ]),
       ]);
@@ -172,7 +172,7 @@ export class Expression<DataType, IsNotNull extends boolean, Name extends string
         new GroupToken([
           new SeparatorToken(
             ',',
-            array.map((item) => new ParameterToken(item)),
+            array.map((item) => expressionValueToken(item)),
           ),
         ]),
       ]);
@@ -243,9 +243,9 @@ export class Expression<DataType, IsNotNull extends boolean, Name extends string
     return new DefaultExpression([
       ...this.tokens,
       new StringToken(`BETWEEN`),
-      new ParameterToken(a),
+      expressionValueToken(a),
       new StringToken(`AND`),
-      new ParameterToken(b),
+      expressionValueToken(b),
     ]);
   }
 
@@ -253,9 +253,9 @@ export class Expression<DataType, IsNotNull extends boolean, Name extends string
     return new DefaultExpression([
       ...this.tokens,
       new StringToken(`BETWEEN SYMMETRIC`),
-      new ParameterToken(a),
+      expressionValueToken(a),
       new StringToken(`AND`),
-      new ParameterToken(b),
+      expressionValueToken(b),
     ]);
   }
 
@@ -263,7 +263,7 @@ export class Expression<DataType, IsNotNull extends boolean, Name extends string
     return new DefaultExpression([
       ...this.tokens,
       new StringToken(`IS DISTINCT FROM`),
-      new ParameterToken(a),
+      expressionValueToken(a),
     ]);
   }
 
@@ -271,7 +271,7 @@ export class Expression<DataType, IsNotNull extends boolean, Name extends string
     return new DefaultExpression([
       ...this.tokens,
       new StringToken(`IS NOT DISTINCT FROM`),
-      new ParameterToken(a),
+      expressionValueToken(a),
     ]);
   }
 
@@ -279,7 +279,7 @@ export class Expression<DataType, IsNotNull extends boolean, Name extends string
     return new DefaultExpression([
       ...this.tokens,
       new StringToken(`LIKE`),
-      new ParameterToken(value),
+      expressionValueToken(value),
     ]);
   }
 
@@ -287,7 +287,7 @@ export class Expression<DataType, IsNotNull extends boolean, Name extends string
     return new DefaultExpression([
       ...this.tokens,
       new StringToken(`ILIKE`),
-      new ParameterToken(value),
+      expressionValueToken(value),
     ]);
   }
 

--- a/src/select.ts
+++ b/src/select.ts
@@ -1,5 +1,6 @@
 import {
   CollectionToken,
+  expressionValueToken,
   GroupToken,
   ParameterToken,
   SeparatorToken,
@@ -316,7 +317,7 @@ export class SelectQuery<
   ): SelectQuery<Columns, IncludesStar> {
     const joinConditionToken = isTokenable(joinCondition)
       ? new GroupToken(joinCondition.toTokens())
-      : new ParameterToken(joinCondition);
+      : expressionValueToken(joinCondition);
 
     return this.newSelectQuery([...this.tokens, new StringToken(`ON`), joinConditionToken]) as any;
   }

--- a/src/sql-functions.ts
+++ b/src/sql-functions.ts
@@ -2,6 +2,7 @@ import {
   AllStarToken,
   CollectionToken,
   EmptyToken,
+  expressionValueToken,
   GroupToken,
   ParameterToken,
   SeparatorToken,
@@ -56,6 +57,38 @@ export function raw<DataType, IsNotNull extends boolean = false, Name extends st
   });
 
   return new Expression<DataType, IsNotNull, Name>(tokens, '' as any);
+}
+
+// Inlines a value directly into the SQL text instead of sending it as a bound parameter.
+//
+// Useful when you want the Postgres planner to see the actual constant — e.g. comparing a
+// boolean column to `TRUE`/`FALSE` so the planner can use a partial index or fold the
+// predicate, which it cannot do for `column = $1` because it does not know what $1 will be.
+//
+// Only types that are unambiguously safe to render as SQL text are accepted (boolean, finite
+// number, bigint). String values are intentionally not supported here to avoid SQL injection
+// risk — use `raw` if you really need to inline a string literal yourself.
+export function literal(value: boolean): Expression<boolean, true, '?column?'>;
+export function literal(value: number): Expression<number, true, '?column?'>;
+export function literal(value: bigint): Expression<bigint, true, '?column?'>;
+export function literal(value: boolean | number | bigint): Expression<any, true, '?column?'> {
+  let sql: string;
+  if (typeof value === 'boolean') {
+    sql = value ? 'TRUE' : 'FALSE';
+  } else if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new Error(`literal() does not support non-finite numbers, got ${value}`);
+    }
+    sql = String(value);
+  } else if (typeof value === 'bigint') {
+    sql = value.toString();
+  } else {
+    throw new Error(
+      `literal() only supports boolean, number, or bigint values; got ${typeof value}`,
+    );
+  }
+
+  return new Expression([new StringToken(sql)], '?column?');
 }
 
 export function star(): Star;
@@ -235,7 +268,7 @@ export const coalesce = <DataType>(
           expressions.map((expression) =>
             expression instanceof Expression
               ? new CollectionToken(expression.toTokens())
-              : new ParameterToken(expression),
+              : expressionValueToken(expression),
           ),
         ),
       ]),

--- a/src/tokens/parameter-token.ts
+++ b/src/tokens/parameter-token.ts
@@ -1,4 +1,5 @@
 import { State, Token } from './token';
+import { StringToken } from './string-token';
 
 export class ParameterToken extends Token {
   parameter: any;
@@ -22,3 +23,27 @@ export class ParameterToken extends Token {
     return state;
   }
 }
+
+// Returns a `StringToken` for values that are both SQL-injection safe and beneficial to inline
+// as a literal in the generated SQL, otherwise a `ParameterToken`.
+//
+// We currently only auto-inline booleans. That lets `column.eq(true)` emit `column = TRUE`
+// rather than `column = $1`, which lets the Postgres planner fold the predicate (and e.g.
+// choose a partial index) — something it cannot do for a bind parameter because it does not
+// know what value will be supplied. Booleans are an unambiguous win because there are only two
+// possible values, so there is no plan-cache concern.
+//
+// Numbers and bigints are intentionally NOT auto-inlined: they are safe to render textually,
+// but inlining them pollutes the plan cache (every distinct value gets its own plan) and
+// defeats prepared-statement reuse. Use `literal()` if you want to opt those in explicitly.
+//
+// Only used for expression-building paths (comparisons, arithmetic, JOIN ON, CASE, COALESCE,
+// etc). INSERT VALUES and UPDATE SET still go through `ParameterToken` directly so that the
+// same statement can be reused as a prepared statement across rows.
+export const expressionValueToken = (value: unknown): ParameterToken | StringToken => {
+  if (typeof value === 'boolean') {
+    return new StringToken(value ? 'TRUE' : 'FALSE');
+  }
+
+  return new ParameterToken(value);
+};


### PR DESCRIPTION
Boolean values passed into expression-building APIs (`eq` / `ne` / `gt` / `in` / `between` / `like` / `isDistinctFrom` / `coalesce` / `case().when(...).then(...)` / `joinLateral(...).on(true)` / etc.) are now rendered as the SQL literals `TRUE` / `FALSE` instead of being sent as bound parameters. This lets the Postgres planner fold the predicate and use partial indexes, which it cannot do for `column = $1` because it does not know what the bind value will be. Booleans only have two possible values so there is no plan-cache downside to inlining them.

`INSERT VALUES` and `UPDATE SET` still parameterize booleans so the same statement can be reused as a prepared statement across rows.

Also adds a `literal()` helper for opt-in inlining of `number` and `bigint` values. Those aren't auto-inlined because each distinct numeric constant becomes its own plan-cache entry and defeats prepared-statement reuse — when you actually want that trade-off (e.g. comparing to a fixed `0` or `1`), `literal(0)` makes it explicit.

Implementation is a single `expressionValueToken` helper in `src/tokens/parameter-token.ts` that all expression-building sites now route through, so the decision lives in one place.

⚠ Behavior change: existing queries comparing against booleans will see `TRUE`/`FALSE` in the SQL text instead of `$N`, and the boolean will no longer appear in the parameters array. Downstream snapshot tests / query-log assertions / parameter-count middleware may need updating.

### Testing

- [x] unit tests
