### PR TITLE
Fix case to use `CASE` and `END`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This fork is based on the 1.x version rather than newer 2.x version.  We made th
 - Make .in(...) and .notIn(...) accept read-only arrays as well.
 - Add support for `MATERIALIZED` and `NOT MATERIALIZED` modifier on CTEs.
 - Add an explicit `.execute()` method. It's not necessary, but using it results in better stack traces.
+- Add `CASE` and `END` to case statements.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anrok/mammoth",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anrok/mammoth",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@anrok/mammoth",
   "license": "MIT",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "main": "./.build/index.js",
   "types": "./.build/index.d.ts",
   "keywords": [

--- a/src/__tests__/select.test.ts
+++ b/src/__tests__/select.test.ts
@@ -977,7 +977,7 @@ describe(`select`, () => {
           "great",
           "not great",
         ],
-        "text": "SELECT foo.id, (WHEN foo.value > $1 THEN $2 ELSE $3) greatness FROM foo",
+        "text": "SELECT foo.id, (CASE WHEN foo.value > $1 THEN $2 ELSE $3 END) greatness FROM foo",
       }
     `);
   });

--- a/src/case.ts
+++ b/src/case.ts
@@ -5,7 +5,7 @@ import { Expression } from './expression';
 
 export class CaseStatement<DataType> {
   static make(): CaseStatement<never> {
-    return new CaseStatement<never>([new StringToken(`CASE`)]);
+    return new CaseStatement<never>([]);
   }
 
   private constructor(private readonly tokens: Token[]) {}
@@ -34,6 +34,9 @@ export class CaseStatement<DataType> {
   }
 
   end(): Expression<DataType, true, 'case'> {
-    return new Expression([...this.tokens, new StringToken(`END`)], `case`);
+    return new Expression(
+      [new StringToken(`CASE`), ...this.tokens, new StringToken(`END`)],
+      `case`,
+    );
   }
 }

--- a/src/case.ts
+++ b/src/case.ts
@@ -30,6 +30,6 @@ export class CaseStatement<DataType> {
   }
 
   end(): Expression<DataType, true, 'case'> {
-    return new Expression(this.tokens, `case`);
+    return new Expression([...this.tokens, new StringToken(`END`)], `case`);
   }
 }

--- a/src/case.ts
+++ b/src/case.ts
@@ -4,7 +4,7 @@ import { ParameterToken, StringToken, Token } from './tokens';
 import { Expression } from './expression';
 
 export class CaseStatement<DataType> {
-  static create(): CaseStatement<never> {
+  static make(): CaseStatement<never> {
     return new CaseStatement<never>([new StringToken(`CASE`)]);
   }
 

--- a/src/case.ts
+++ b/src/case.ts
@@ -4,7 +4,11 @@ import { ParameterToken, StringToken, Token } from './tokens';
 import { Expression } from './expression';
 
 export class CaseStatement<DataType> {
-  constructor(private readonly tokens: Token[]) {}
+  static create(): CaseStatement<never> {
+    return new CaseStatement<never>([new StringToken(`CASE`)]);
+  }
+
+  private constructor(private readonly tokens: Token[]) {}
 
   when<Q extends Query<any>>(expression: Expression<boolean, boolean, string> | BooleanQuery<Q>) {
     const self = this;

--- a/src/db.ts
+++ b/src/db.ts
@@ -88,7 +88,7 @@ export const defineDb = <TableDefinitions extends { [key: string]: TableDefiniti
     ...makeQueryStartFunctions(queryExecutor, []),
     with: makeWith(),
     values: makeValues,
-    case: () => CaseStatement.create(),
+    case: () => CaseStatement.make(),
     ...sqlFunctions,
 
     ...createTables(tableDefinitions),

--- a/src/db.ts
+++ b/src/db.ts
@@ -88,7 +88,7 @@ export const defineDb = <TableDefinitions extends { [key: string]: TableDefiniti
     ...makeQueryStartFunctions(queryExecutor, []),
     with: makeWith(),
     values: makeValues,
-    case: () => new CaseStatement<never>([new StringToken(`CASE`)]),
+    case: () => CaseStatement.create(),
     ...sqlFunctions,
 
     ...createTables(tableDefinitions),

--- a/src/db.ts
+++ b/src/db.ts
@@ -88,7 +88,7 @@ export const defineDb = <TableDefinitions extends { [key: string]: TableDefiniti
     ...makeQueryStartFunctions(queryExecutor, []),
     with: makeWith(),
     values: makeValues,
-    case: () => new CaseStatement<never>([]),
+    case: () => new CaseStatement<never>([new StringToken(`CASE`)]),
     ...sqlFunctions,
 
     ...createTables(tableDefinitions),


### PR DESCRIPTION
The case statement was not including the `CASE` and `END` tokens, resulting in invalid SQL.  This fixes it to add these tokens.