### PR TITLE
Add support for expressions in case statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This fork is based on the 1.x version rather than newer 2.x version.  We made th
 - Add support for `MATERIALIZED` and `NOT MATERIALIZED` modifier on CTEs.
 - Add an explicit `.execute()` method. It's not necessary, but using it results in better stack traces.
 - Add `CASE` and `END` to case statements.
+- Add support for expressions in case statements.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anrok/mammoth",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anrok/mammoth",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@anrok/mammoth",
   "license": "MIT",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "main": "./.build/index.js",
   "types": "./.build/index.d.ts",
   "keywords": [

--- a/src/__checks__/select.check.ts
+++ b/src/__checks__/select.check.ts
@@ -290,6 +290,74 @@ describe('select', () => {
     }>();
   });
 
+  test('should select case with not-null expression in then and literal in else', () => {
+    expect(
+      toSnap(
+        db
+          .select(
+            db.case().when(db.foo.value.gt(0)).then(db.foo.name).else('default').end().as(`bar`),
+          )
+          .from(db.foo),
+      ),
+    ).type.toBe<{
+      bar: string;
+    }>();
+  });
+
+  test('should select case with nullable expression in then and literal in else', () => {
+    expect(
+      toSnap(
+        db
+          .select(
+            db.case().when(db.foo.value.gt(0)).then(db.foo.value).else('default').end().as(`bar`),
+          )
+          .from(db.foo),
+      ),
+    ).type.toBe<{
+      bar: number | string | null;
+    }>();
+  });
+
+  test('should select case with literal in then and nullable expression in else', () => {
+    expect(
+      toSnap(
+        db
+          .select(
+            db.case().when(db.foo.value.gt(0)).then('great').else(db.foo.value).end().as(`bar`),
+          )
+          .from(db.foo),
+      ),
+    ).type.toBe<{
+      bar: string | number | null;
+    }>();
+  });
+
+  test('should select case with not-null expressions in both then and else', () => {
+    expect(
+      toSnap(
+        db
+          .select(
+            db.case().when(db.foo.value.gt(0)).then(db.foo.name).else(db.foo.name).end().as(`bar`),
+          )
+          .from(db.foo),
+      ),
+    ).type.toBe<{
+      bar: string;
+    }>();
+  });
+
+  test('should select case with not-null expression in then and null in else', () => {
+    expect(
+      toSnap(
+        db
+          .select(db.case().when(db.foo.value.gt(0)).then(db.foo.name).else(null).end().as(`bar`))
+          .from(db.foo),
+      ),
+    ).type.toBe<{
+      bar: string | null;
+    }>();
+  });
+
   test('should select and await result set', async () => {
     expect(await db.select(db.foo.id, db.foo.value).from(db.foo)).type.toBe<
       {

--- a/src/__tests__/select.test.ts
+++ b/src/__tests__/select.test.ts
@@ -982,6 +982,31 @@ describe(`select`, () => {
     `);
   });
 
+  it(`should select with case and expression and else`, () => {
+    const query = db
+      .select(
+        db.foo.id,
+        db
+          .case()
+          .when(db.foo.value.gt(0))
+          .then(db.foo.value)
+          .else('not great')
+          .end()
+          .as('greatness'),
+      )
+      .from(db.foo);
+
+    expect(toSql(query)).toMatchInlineSnapshot(`
+      {
+        "parameters": [
+          0,
+          "not great",
+        ],
+        "text": "SELECT foo.id, (CASE WHEN foo.value > $1 THEN foo.value ELSE $2 END) greatness FROM foo",
+      }
+    `);
+  });
+
   it(`should select enum column`, () => {
     const query = db.select(db.foo.enumTest).from(db.foo);
 

--- a/src/case.ts
+++ b/src/case.ts
@@ -2,16 +2,17 @@ import { BooleanQuery, Query } from './query';
 import { ParameterToken, StringToken, Token } from './tokens';
 
 import { Expression } from './expression';
+import { isTokenable } from './sql-functions';
 
 type ResultDataType<T> = T extends Expression<infer D, any, any> ? D : T;
 type ResultIsNotNull<T> = T extends Expression<any, infer N extends boolean, any> ? N : true;
 type And<A extends boolean, B extends boolean> = A extends true ? B : false;
 
-function valueToTokens(result: unknown): Token[] {
-  if (result instanceof Expression) {
-    return result.toTokens();
+function valueToTokens(value: unknown): Token[] {
+  if (isTokenable(value)) {
+    return value.toTokens();
   }
-  return [new ParameterToken(result)];
+  return [new ParameterToken(value)];
 }
 
 export class CaseStatement<DataType, IsNotNull extends boolean = true> {

--- a/src/case.ts
+++ b/src/case.ts
@@ -3,9 +3,20 @@ import { ParameterToken, StringToken, Token } from './tokens';
 
 import { Expression } from './expression';
 
-export class CaseStatement<DataType> {
-  static make(): CaseStatement<never> {
-    return new CaseStatement<never>([]);
+type ResultDataType<T> = T extends Expression<infer D, any, any> ? D : T;
+type ResultIsNotNull<T> = T extends Expression<any, infer N extends boolean, any> ? N : true;
+type And<A extends boolean, B extends boolean> = A extends true ? B : false;
+
+function valueToTokens(result: unknown): Token[] {
+  if (result instanceof Expression) {
+    return result.toTokens();
+  }
+  return [new ParameterToken(result)];
+}
+
+export class CaseStatement<DataType, IsNotNull extends boolean = true> {
+  static make(): CaseStatement<never, true> {
+    return new CaseStatement<never, true>([]);
   }
 
   private constructor(private readonly tokens: Token[]) {}
@@ -14,26 +25,26 @@ export class CaseStatement<DataType> {
     const self = this;
     return {
       then<T>(result: T) {
-        return new CaseStatement<DataType | T>([
+        return new CaseStatement<DataType | ResultDataType<T>, And<IsNotNull, ResultIsNotNull<T>>>([
           ...self.tokens,
           new StringToken(`WHEN`),
           ...expression.toTokens(),
           new StringToken(`THEN`),
-          new ParameterToken(result),
+          ...valueToTokens(result),
         ]);
       },
     };
   }
 
   else<T>(result: T) {
-    return new CaseStatement<DataType | T>([
+    return new CaseStatement<DataType | ResultDataType<T>, And<IsNotNull, ResultIsNotNull<T>>>([
       ...this.tokens,
       new StringToken(`ELSE`),
-      new ParameterToken(result),
+      ...valueToTokens(result),
     ]);
   }
 
-  end(): Expression<DataType, true, 'case'> {
+  end(): Expression<DataType, IsNotNull, 'case'> {
     return new Expression(
       [new StringToken(`CASE`), ...this.tokens, new StringToken(`END`)],
       `case`,


### PR DESCRIPTION
Right now, case statements only support parameters in `then` and `else`.  This adds support to be able to use expressions here as well.